### PR TITLE
add GH action to report usage to followers

### DIFF
--- a/.github/workflows/weekly-usage-report.yml
+++ b/.github/workflows/weekly-usage-report.yml
@@ -31,6 +31,8 @@ jobs:
             echo "_$(date -u +'%B %d, %Y')_ · Last 7 days"
             echo ""
             echo '```'
-            python scripts/vertex_usage.py --days 7 --project nmdc-llm
+            if ! python scripts/vertex_usage.py --days 7 --project nmdc-llm; then
+              echo 'Report generation failed. See the "Run token usage report" step logs for details.'
+            fi
             echo '```'
           } >> "$GITHUB_STEP_SUMMARY"

--- a/.github/workflows/weekly-usage-report.yml
+++ b/.github/workflows/weekly-usage-report.yml
@@ -1,0 +1,36 @@
+name: Weekly Usage Report
+
+on:
+  schedule:
+    - cron: "0 16 * * 1"  # Monday 4pm UTC = 8am PT
+  workflow_dispatch:       # Manual trigger for testing
+
+jobs:
+  report:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: google-github-actions/auth@v2
+        with:
+          credentials_json: ${{ secrets.GCP_SA_KEY }}
+
+      - uses: google-github-actions/setup-gcloud@v2
+
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: "3.12"
+
+      - name: Run token usage report
+        run: |
+          {
+            echo "## NMDC LLM Weekly Token Usage Report"
+            echo "_$(date -u +'%B %d, %Y')_ · Last 7 days"
+            echo ""
+            echo '```'
+            python scripts/vertex_usage.py --days 7 --project nmdc-llm
+            echo '```'
+          } >> "$GITHUB_STEP_SUMMARY"

--- a/.github/workflows/weekly-usage-report.yml
+++ b/.github/workflows/weekly-usage-report.yml
@@ -8,6 +8,7 @@ on:
 jobs:
   report:
     runs-on: ubuntu-latest
+    timeout-minutes: 10
     permissions:
       contents: read
     steps:
@@ -26,13 +27,16 @@ jobs:
 
       - name: Run token usage report
         run: |
+          REPORT_FAILED=0
           {
             echo "## NMDC LLM Weekly Token Usage Report"
             echo "_$(date -u +'%B %d, %Y')_ · Last 7 days"
             echo ""
             echo '```'
             if ! python scripts/vertex_usage.py --days 7 --project nmdc-llm; then
-              echo 'Report generation failed. See the "Run token usage report" step logs for details.'
+              echo 'Report generation failed. See step logs for details.'
+              REPORT_FAILED=1
             fi
             echo '```'
           } >> "$GITHUB_STEP_SUMMARY"
+          exit "$REPORT_FAILED"

--- a/scripts/vertex_usage.py
+++ b/scripts/vertex_usage.py
@@ -11,6 +11,8 @@ import argparse
 import json
 import subprocess
 import sys
+import urllib.error
+import urllib.request
 from collections import defaultdict
 from datetime import UTC, datetime, timedelta
 
@@ -69,15 +71,13 @@ def query_token_usage(project_id, days):
         f"&interval.endTime={now.strftime('%Y-%m-%dT%H:%M:%SZ')}"
     )
 
-    result = subprocess.run(
-        ["curl", "-s", "-H", f"Authorization: Bearer {token}", url],
-        capture_output=True, text=True
-    )
-    if result.returncode != 0:
-        print(f"Error querying monitoring API: {result.stderr}", file=sys.stderr)
+    req = urllib.request.Request(url, headers={"Authorization": f"Bearer {token}"})
+    try:
+        with urllib.request.urlopen(req) as resp:
+            return json.loads(resp.read().decode())
+    except urllib.error.URLError as exc:
+        print(f"Error querying monitoring API: {exc}", file=sys.stderr)
         sys.exit(1)
-
-    return json.loads(result.stdout)
 
 
 def aggregate(data):


### PR DESCRIPTION
Adds a GitHub Actions workflow that runs scripts/vertex_usage.py every Monday at 8 am PT and writes the token usage/cost report to the Job Summary. Also supports manual triggering via workflow_dispatch for testing.
                                                                                                                                
Requires one-time setup: a GCP service account with roles/monitoring.viewer on nmdc-llm, with its JSON key stored as the GCP_SA_KEY GitHub secret. Recipients need to watch the repo with workflow notifications enabled to get emailed (ping me if you want access to GCP_SA_KEY). 
                                                                     
Just adds .github/workflows/weekly-usage-report.yml.
