### PR TITLE
Use logging instead of print in library code

### DIFF
--- a/src/nmdc_metadata_suggestor_ai_tool/publication_ingestion/download_pdf.py
+++ b/src/nmdc_metadata_suggestor_ai_tool/publication_ingestion/download_pdf.py
@@ -1,9 +1,12 @@
+import logging
 import os
 import tempfile
 from urllib.parse import urlparse
 
 import requests
 from curl_cffi import requests as cffi_requests
+
+logger = logging.getLogger(__name__)
 
 # Domains known to use Cloudflare JS challenges that require browser-like
 # TLS fingerprints.  curl_cffi (via curl-impersonate) is used for these;
@@ -39,7 +42,7 @@ def download_pdf_to_tempfile(url: str) -> str:
     try:
         fd, temp_path = tempfile.mkstemp(suffix=".pdf")
         os.close(fd)
-        print(f"Temporary file created at: {temp_path}")
+        logger.debug(f"Temporary file created at: {temp_path}")
 
         if _needs_browser_impersonation(url):
             _download_with_cffi(url, temp_path)
@@ -81,9 +84,9 @@ def remove_temp_file(path: str) -> None:
     try:
         if os.path.exists(path):
             os.remove(path)
-            print(f"Temporary file {path} deleted.")
-    except Exception as e:
-        print(f"Error deleting temporary file {path}: {e}")
+            logger.debug(f"Temporary file {path} deleted.")
+    except Exception:
+        logger.exception(f"Error deleting temporary file {path}")
 
 
 if __name__ == "__main__":

--- a/src/nmdc_metadata_suggestor_ai_tool/recommendation_pipeline.py
+++ b/src/nmdc_metadata_suggestor_ai_tool/recommendation_pipeline.py
@@ -1,4 +1,5 @@
 import json
+import logging
 import re
 
 from pydantic import ValidationError
@@ -13,17 +14,19 @@ from nmdc_metadata_suggestor_ai_tool.publication_ingestion.download_pdf import (
 from nmdc_metadata_suggestor_ai_tool.schema_context import SchemaContextBuilder
 from nmdc_metadata_suggestor_ai_tool.utils.submission_parser import get_submission_fields
 
+logger = logging.getLogger(__name__)
+
 
 def clean_and_validate_output(raw_output: str) -> LLMOutput:
     """Clean the raw output from the LLM and validate it against the expected schema"""
-    print(f"Raw LLM output: {raw_output}")
+    logger.debug(f"Raw LLM output: {raw_output}")
     cleaned_response = re.sub(
         r"^```(?:json)?\s*\n?|\n?```$",
         "",
         raw_output.strip(),
         flags=re.MULTILINE,
     ).strip()
-    print(f"Cleaned LLM response: {cleaned_response}")
+    logger.debug(f"Cleaned LLM response: {cleaned_response}")
     try:
         parsed_response = json.loads(cleaned_response)
     except json.JSONDecodeError as exc:
@@ -104,8 +107,8 @@ def run_recommendation_pipeline(
             try:
                 pdf_path = download_pdf_to_tempfile(str(url))
                 pdf_files.append(pdf_path)
-            except Exception as e:
-                print(f"Error downloading PDF from {url}: {e}")
+            except Exception:
+                logger.exception(f"Error downloading PDF from {url}")
     else:
         pdf_files = None
 

--- a/src/nmdc_metadata_suggestor_ai_tool/utils/submission_parser.py
+++ b/src/nmdc_metadata_suggestor_ai_tool/utils/submission_parser.py
@@ -1,4 +1,7 @@
+import logging
 from enum import Enum
+
+logger = logging.getLogger(__name__)
 
 
 class MixisExtensions(Enum):
@@ -103,7 +106,7 @@ def get_submission_fields(submission_object: dict) -> dict:
         try:
             mixis_extensions.append(MixisExtensions(ext).name)
         except ValueError:
-            print(f"Warning: Unrecognized mixis extension '{ext}' in submission data.")
+            logger.warning(f"Unrecognized mixis extension '{ext}' in submission data.")
 
     # combine and dedupe DOI list[dict]
     combined_dois = make_unique_doi_list(data_dois + publication_dois + awarddois + protocol_dois)


### PR DESCRIPTION
These changes replace the use of `print` with use of the `logging` module in code that is hit by clients of this library. These print statements were generating a lot of noise in the `nmdc-server` logs.