### PR TITLE
Add Elsevier and Springer Nature as waterfall sources

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -27,6 +27,15 @@ CONTACT_EMAIL=support@microbiomedata.org
 # Request at https://docs.openalex.org/how-to-use-the-api/api-key
 # OPENALEX_API_KEY=
 
+# Elsevier ScienceDirect API key (optional — enables Elsevier abstract retrieval).
+# Register at https://dev.elsevier.com/
+# ELSEVIER_API_KEY=
+
+# Springer Nature API keys (optional — enables Springer Nature abstract retrieval).
+# Register at https://dev.springernature.com/
+# SPRINGER_NATURE_API_KEY=
+# SPRINGER_NATURE_OA_API_KEY=
+
 # Unpaywall email (required — used as the email param in API calls).
 # See https://unpaywall.org/products/api
 # UNPAYWALL_EMAIL=

--- a/src/nmdc_metadata_suggestor_ai_tool/constants.py
+++ b/src/nmdc_metadata_suggestor_ai_tool/constants.py
@@ -12,7 +12,15 @@ import re
 # ---------------------------------------------------------------------------
 # Supported sources for abstract and publication retrieval
 # ---------------------------------------------------------------------------
-ALL_SOURCES = ("openalex", "crossref", "pubmed", "content_negotiation", "osti")
+ALL_SOURCES = (
+    "openalex",
+    "crossref",
+    "elsevier",
+    "springer_nature",
+    "pubmed",
+    "content_negotiation",
+    "osti",
+)
 
 # ---------------------------------------------------------------------------
 # Contact / User-Agent
@@ -57,6 +65,18 @@ EUROPEPMC_API_URL = "https://www.ebi.ac.uk/europepmc/webservices/rest/search"
 PUBMED_ID_CONVERTER = "https://www.ncbi.nlm.nih.gov/pmc/utils/idconv/v1.0/"
 PUBMED_EFETCH = "https://eutils.ncbi.nlm.nih.gov/entrez/eutils/efetch.fcgi"
 PMC_PDF_URL_TEMPLATE = "https://www.ncbi.nlm.nih.gov/pmc/articles/{pmcid}/pdf/"
+
+# Elsevier ScienceDirect — requires API key from https://dev.elsevier.com/
+# The API key is read at call time via os.environ.get("ELSEVIER_API_KEY")
+# in doi_ingestion/elsevier.py (not captured here, to avoid import-time issues).
+ELSEVIER_API_URL = "https://api.elsevier.com/content/article/doi"
+
+# Springer Nature APIs — require keys from https://dev.springernature.com/
+#   "Meta API" key     → /meta/v2/   (SPRINGER_NATURE_API_KEY)
+#   "Open Access API"  → /openaccess/ (SPRINGER_NATURE_OA_API_KEY)
+# Keys are read at call time in doi_ingestion/springer_nature.py.
+SPRINGER_NATURE_META_API_URL = "https://api.springernature.com/meta/v2/json"
+SPRINGER_NATURE_OA_API_URL = "https://api.springernature.com/openaccess/json"
 
 # Content negotiation
 CITEPROC_JSON_ACCEPT = "application/vnd.citationstyles.csl+json"

--- a/src/nmdc_metadata_suggestor_ai_tool/doi_ingestion/elsevier.py
+++ b/src/nmdc_metadata_suggestor_ai_tool/doi_ingestion/elsevier.py
@@ -1,0 +1,116 @@
+"""Elsevier ScienceDirect abstract retrieval for 10.1016 DOIs.
+
+Elsevier withholds abstracts from Crossref, so the standard waterfall
+(OpenAlex -> Crossref -> PubMed -> content negotiation) fails for most
+10.1016 DOIs. This module queries the ScienceDirect API directly.
+
+API docs: https://dev.elsevier.com/documentation/AbstractRetrievalAPI.doc
+"""
+
+import logging
+import os
+
+import requests
+
+from nmdc_metadata_suggestor_ai_tool.constants import (
+    DEFAULT_TIMEOUT,
+    ELSEVIER_API_URL,
+)
+from nmdc_metadata_suggestor_ai_tool.doi_ingestion.doi_utils import (
+    append_error,
+    clean_text,
+    request_with_retry,
+)
+from nmdc_metadata_suggestor_ai_tool.models.resolver_context import ResolverContext
+
+LOGGER = logging.getLogger(__name__)
+
+ELSEVIER_DOI_PREFIX = "10.1016/"
+
+
+def try_elsevier(doi: str, errors: list[str] | None = None) -> ResolverContext | None:
+    """Return Elsevier abstract context for DOI ingestion waterfall.
+
+    Compatible with the ``doi_ingestion/main.py`` resolver interface.
+    """
+    text, raw = _fetch_elsevier_abstract(doi, errors)
+    if text:
+        return ResolverContext(text=text, raw_text=raw or "", kind="abstract", source="elsevier")
+    return None
+
+
+def try_elsevier_abstract(doi: str) -> tuple[str | None, str | None, str | None]:
+    """Fetch abstract from Elsevier for publication abstract retrieval waterfall.
+
+    Matches the ``try_crossref_abstract`` signature:
+    returns ``(cleaned_text, raw_text, content_format)`` tuple.
+    """
+    text, raw = _fetch_elsevier_abstract(doi)
+    if text:
+        return text, raw, "plain_text"
+    return None, None, None
+
+
+def _fetch_elsevier_abstract(
+    doi: str, errors: list[str] | None = None
+) -> tuple[str | None, str | None]:
+    """Shared internal logic for both public entry points.
+
+    Returns ``(cleaned_text, raw_text)`` or ``(None, None)`` on failure.
+    """
+    api_key = os.environ.get("ELSEVIER_API_KEY")
+    if not api_key:
+        LOGGER.debug("Elsevier API key not configured, skipping")
+        return None, None
+
+    if not doi.startswith(ELSEVIER_DOI_PREFIX):
+        return None, None
+
+    try:
+        response = request_with_retry(
+            "GET",
+            f"{ELSEVIER_API_URL}/{doi}",
+            headers={
+                "X-ELS-APIKey": api_key,
+                "Accept": "application/json",
+            },
+            timeout=DEFAULT_TIMEOUT,
+        )
+        _log_rate_limit(response)
+        if response.status_code != 200:
+            append_error(errors, f"Elsevier API returned HTTP {response.status_code}")
+            return None, None
+
+        data = response.json()
+    except requests.RequestException as exc:
+        append_error(errors, f"Elsevier API request failed: {exc.__class__.__name__}")
+        return None, None
+    except ValueError:
+        append_error(errors, "Elsevier API returned invalid JSON")
+        return None, None
+
+    coredata = data.get("full-text-retrieval-response", {}).get("coredata", {})
+    raw = coredata.get("dc:description")
+    if not isinstance(raw, str) or not raw.strip():
+        append_error(errors, "Elsevier response contained no dc:description")
+        return None, None
+
+    cleaned = clean_text(raw)
+    if not cleaned:
+        append_error(errors, "Elsevier abstract was empty after cleaning")
+        return None, None
+
+    return cleaned, raw
+
+
+def _log_rate_limit(response: requests.Response) -> None:
+    """Log Elsevier API rate-limit headers for quota monitoring."""
+    remaining = response.headers.get("X-RateLimit-Remaining")
+    limit = response.headers.get("X-RateLimit-Limit")
+    if remaining is not None:
+        LOGGER.info("Elsevier API quota: %s/%s remaining", remaining, limit or "?")
+        try:
+            if int(remaining) < 100:
+                LOGGER.warning("Elsevier API quota low: %s remaining", remaining)
+        except ValueError:
+            pass

--- a/src/nmdc_metadata_suggestor_ai_tool/doi_ingestion/main.py
+++ b/src/nmdc_metadata_suggestor_ai_tool/doi_ingestion/main.py
@@ -20,6 +20,7 @@ from nmdc_metadata_suggestor_ai_tool.doi_ingestion.doi_utils import (
     normalize_doi,
 )
 from nmdc_metadata_suggestor_ai_tool.doi_ingestion.edi import try_edi
+from nmdc_metadata_suggestor_ai_tool.doi_ingestion.elsevier import try_elsevier
 from nmdc_metadata_suggestor_ai_tool.doi_ingestion.emsl import try_emsl
 from nmdc_metadata_suggestor_ai_tool.doi_ingestion.ess_dive import try_ess_dive
 from nmdc_metadata_suggestor_ai_tool.doi_ingestion.figshare import try_figshare
@@ -29,6 +30,7 @@ from nmdc_metadata_suggestor_ai_tool.doi_ingestion.massive import try_massive
 from nmdc_metadata_suggestor_ai_tool.doi_ingestion.openalex import try_openalex
 from nmdc_metadata_suggestor_ai_tool.doi_ingestion.osti import try_osti
 from nmdc_metadata_suggestor_ai_tool.doi_ingestion.pubmed import try_pubmed
+from nmdc_metadata_suggestor_ai_tool.doi_ingestion.springer_nature import try_springer_nature
 from nmdc_metadata_suggestor_ai_tool.doi_ingestion.zenodo import try_zenodo
 from nmdc_metadata_suggestor_ai_tool.models.doi import DoiClassification, SourceRetrievalResult
 from nmdc_metadata_suggestor_ai_tool.models.resolver_context import ResolverContext
@@ -442,6 +444,24 @@ def _fetch_pubmed(
     return _fetch_resolver_context(doi, provider, "pubmed", attempts, source_errors, try_pubmed)
 
 
+def _fetch_elsevier(
+    doi: str, provider: str | None, attempts: list[str], source_errors: SourceErrors
+) -> SourceRetrievalResult | None:
+    """Fetch and wrap context from Elsevier ScienceDirect API."""
+    return _fetch_resolver_context(
+        doi, provider, "elsevier", attempts, source_errors, try_elsevier
+    )
+
+
+def _fetch_springer_nature(
+    doi: str, provider: str | None, attempts: list[str], source_errors: SourceErrors
+) -> SourceRetrievalResult | None:
+    """Fetch and wrap context from Springer Nature APIs."""
+    return _fetch_resolver_context(
+        doi, provider, "springer_nature", attempts, source_errors, try_springer_nature
+    )
+
+
 def _fetch_osti(
     doi: str, provider: str | None, attempts: list[str], source_errors: SourceErrors
 ) -> SourceRetrievalResult | None:
@@ -461,6 +481,8 @@ _SOURCE_FETCHERS: dict[str, Fetcher] = {
     "zenodo": _fetch_zenodo,
     "datacite": _fetch_datacite,
     "crossref": _fetch_crossref,
+    "elsevier": _fetch_elsevier,
+    "springer_nature": _fetch_springer_nature,
     "content_negotiation": _fetch_content_negotiation,
     "openalex": _fetch_openalex,
     "pubmed": _fetch_pubmed,

--- a/src/nmdc_metadata_suggestor_ai_tool/doi_ingestion/springer_nature.py
+++ b/src/nmdc_metadata_suggestor_ai_tool/doi_ingestion/springer_nature.py
@@ -1,0 +1,156 @@
+"""Springer Nature API abstract retrieval for 10.1007 and 10.1038 DOIs.
+
+Springer Nature provides abstracts via two free APIs, each requiring its own key
+from https://dev.springernature.com/:
+
+  - **Meta API v2** (``SPRINGER_NATURE_API_KEY``) — covers all Springer Nature
+    content including paywalled articles.  Abstracts from non-OA articles are
+    subject to Section 8.2 generative-AI restrictions.
+  - **Open Access API** (``SPRINGER_NATURE_OA_API_KEY``) — OA content only,
+    all CC-licensed with no AI restrictions.
+
+The module tries Meta API first (broader coverage), then falls back to the
+Open Access API.
+
+API docs: https://dev.springernature.com/docs/api-endpoints/metadata-api
+"""
+
+import logging
+import os
+
+import requests
+
+from nmdc_metadata_suggestor_ai_tool.constants import (
+    DEFAULT_TIMEOUT,
+    SPRINGER_NATURE_META_API_URL,
+    SPRINGER_NATURE_OA_API_URL,
+)
+from nmdc_metadata_suggestor_ai_tool.doi_ingestion.doi_utils import (
+    append_error,
+    clean_text,
+    request_with_retry,
+)
+from nmdc_metadata_suggestor_ai_tool.models.resolver_context import ResolverContext
+
+LOGGER = logging.getLogger(__name__)
+
+SPRINGER_NATURE_DOI_PREFIXES = ("10.1007/", "10.1038/")
+
+
+def try_springer_nature(doi: str, errors: list[str] | None = None) -> ResolverContext | None:
+    """Return Springer Nature abstract context for DOI ingestion waterfall.
+
+    Compatible with the ``doi_ingestion/main.py`` resolver interface.
+    """
+    text, raw = _fetch_springer_nature_abstract(doi, errors)
+    if text:
+        return ResolverContext(
+            text=text, raw_text=raw or "", kind="abstract", source="springer_nature"
+        )
+    return None
+
+
+def try_springer_nature_abstract(doi: str) -> tuple[str | None, str | None, str | None]:
+    """Fetch abstract from Springer Nature for publication abstract retrieval waterfall.
+
+    Matches the ``try_crossref_abstract`` signature:
+    returns ``(cleaned_text, raw_text, content_format)`` tuple.
+    """
+    text, raw = _fetch_springer_nature_abstract(doi)
+    if text:
+        return text, raw, "plain_text"
+    return None, None, None
+
+
+def _fetch_springer_nature_abstract(
+    doi: str, errors: list[str] | None = None
+) -> tuple[str | None, str | None]:
+    """Shared internal logic for both public entry points.
+
+    Tries the Meta API v2 first (broader coverage), then falls back to the
+    Open Access API.  Each requires its own key.
+
+    Returns ``(cleaned_text, raw_text)`` or ``(None, None)`` on failure.
+    """
+    if not any(doi.startswith(prefix) for prefix in SPRINGER_NATURE_DOI_PREFIXES):
+        return None, None
+
+    # Build list of (url, key, label) to try in order.
+    endpoints: list[tuple[str, str, str]] = []
+    meta_key = os.environ.get("SPRINGER_NATURE_API_KEY")
+    oa_key = os.environ.get("SPRINGER_NATURE_OA_API_KEY")
+    if meta_key:
+        endpoints.append((SPRINGER_NATURE_META_API_URL, meta_key, "Meta API v2"))
+    if oa_key:
+        endpoints.append((SPRINGER_NATURE_OA_API_URL, oa_key, "Open Access API"))
+
+    if not endpoints:
+        LOGGER.debug("No Springer Nature API keys configured, skipping")
+        return None, None
+
+    for url, key, label in endpoints:
+        result = _try_endpoint(doi, url, key, label, errors)
+        if result != (None, None):
+            return result
+
+    return None, None
+
+
+def _try_endpoint(
+    doi: str,
+    api_url: str,
+    api_key: str,
+    label: str,
+    errors: list[str] | None = None,
+) -> tuple[str | None, str | None]:
+    """Try a single Springer Nature endpoint. Returns (cleaned, raw) or (None, None)."""
+    try:
+        response = request_with_retry(
+            "GET",
+            api_url,
+            params={
+                "api_key": api_key,
+                "q": f"doi:{doi}",
+                "p": "1",
+            },
+            timeout=DEFAULT_TIMEOUT,
+        )
+        _log_rate_limit(response)
+        if response.status_code != 200:
+            append_error(errors, f"Springer Nature {label} returned HTTP {response.status_code}")
+            return None, None
+
+        data = response.json()
+    except requests.RequestException as exc:
+        append_error(errors, f"Springer Nature {label} request failed: {exc.__class__.__name__}")
+        return None, None
+    except ValueError:
+        append_error(errors, f"Springer Nature {label} returned invalid JSON")
+        return None, None
+
+    records = data.get("records", [])
+    if not records:
+        return None, None
+
+    raw = records[0].get("abstract")
+    if not isinstance(raw, str) or not raw.strip():
+        return None, None
+
+    cleaned = clean_text(raw)
+    if not cleaned:
+        return None, None
+
+    return cleaned, raw
+
+
+def _log_rate_limit(response: requests.Response) -> None:
+    """Log Springer Nature API rate-limit headers for quota monitoring."""
+    remaining = response.headers.get("X-RateLimit-Remaining")
+    limit = response.headers.get("X-RateLimit-Limit")
+    if remaining is not None:
+        LOGGER.info("Springer Nature API quota: %s/%s remaining", remaining, limit or "?")
+        try:
+            if int(remaining) < 100:
+                LOGGER.warning("Springer Nature API quota low: %s remaining", remaining)
+        except ValueError:
+            pass

--- a/tests/test_abstract_retriever.py
+++ b/tests/test_abstract_retriever.py
@@ -615,7 +615,15 @@ class TestSourceSelection:
 
     def test_all_sources_constant(self) -> None:
         """ALL_SOURCES constant lists the canonical publication abstract sources."""
-        assert set(ALL_SOURCES) == {"openalex", "crossref", "pubmed", "content_negotiation", "osti"}
+        assert set(ALL_SOURCES) == {
+            "openalex",
+            "crossref",
+            "elsevier",
+            "springer_nature",
+            "pubmed",
+            "content_negotiation",
+            "osti",
+        }
 
     @responses.activate
     def test_default_source_order(self) -> None:


### PR DESCRIPTION
## Summary
- Add `elsevier.py` and `springer_nature.py` DOI ingestion modules (ported from #16, updated for package rename)
- Wire both into the source fetcher waterfall in `main.py`
- Add API URL constants and `.env.example` entries for API keys
- Update `ALL_SOURCES` and its test

Supersedes #16 (which targeted the old `nmdc_metadata_suggestor` package path).

## Test plan
- [x] All 191 tests pass (35 deselected integration tests)
- [x] `ruff check` and `ruff format --check` pass
- [ ] Integration test with real Elsevier/Springer API keys

🤖 Generated with [Claude Code](https://claude.com/claude-code)