### PR TITLE
Fix interface_name character-split bug, with tests

### DIFF
--- a/src/nmdc_metadata_suggestor_ai_tool/recommendation_pipeline.py
+++ b/src/nmdc_metadata_suggestor_ai_tool/recommendation_pipeline.py
@@ -49,7 +49,12 @@ def run_recommendation_pipeline(
         conversation_manager.add_message(
             text="Use the PDFs to inform your suggestions", pdf_files=pdf_files
         )
-    # fall back to the submission object if an interface is not specified
+    # Resolve a supplied interface_name to MIxS interface class names via
+    # map_to_interface_name, which accepts a value ("soil") or a class name
+    # ("SoilInterface"). It takes a list, so wrap the single value. Do not pass
+    # the bare string to list(): that iterates it into characters
+    # ("soil" -> ["s", "o", "i", "l"]) and the interface lookup then fails.
+    # When no interface_name is given, fall back to the submission object.
     mixs_extensions = (
         MixsExtensions.map_to_interface_name([interface_name])
         if interface_name

--- a/src/nmdc_metadata_suggestor_ai_tool/recommendation_pipeline.py
+++ b/src/nmdc_metadata_suggestor_ai_tool/recommendation_pipeline.py
@@ -6,7 +6,10 @@ from nmdc_metadata_suggestor_ai_tool.publication_ingestion.download_pdf import r
 from nmdc_metadata_suggestor_ai_tool.schema_context import SchemaContextBuilder
 from nmdc_metadata_suggestor_ai_tool.system_prompt import system_prompt
 from nmdc_metadata_suggestor_ai_tool.utils.build_submission_context import build_submission_context
-from nmdc_metadata_suggestor_ai_tool.utils.submission_parser import get_submission_fields
+from nmdc_metadata_suggestor_ai_tool.utils.submission_parser import (
+    MixsExtensions,
+    get_submission_fields,
+)
 from nmdc_metadata_suggestor_ai_tool.utils.utils import validate_output
 
 logger = logging.getLogger(__name__)
@@ -23,8 +26,10 @@ def run_recommendation_pipeline(
     Parameters:
         submission_object: Raw submission object containing NMDC metadata fields.
         llm_client: LLMClient instance used for model interaction.
+        interface_name: Optional specific interface to work from. Accepts either a
+            MIxS package value ("soil") or an interface class name ("SoilInterface").
+            When given, it overrides the interfaces parsed from the submission object.
         max_tokens: Optional maximum number of output response tokens.
-        interface_tab  : Optional, specific interface tab to work from
 
     Returns:
         The response from the LLM containing the recommended metadata fields.
@@ -44,9 +49,9 @@ def run_recommendation_pipeline(
         conversation_manager.add_message(
             text="Use the PDFs to inform your suggestions", pdf_files=pdf_files
         )
-    # fall back to submisison object if interface tab is not specified
+    # fall back to the submission object if an interface is not specified
     mixs_extensions = (
-        list(interface_name)
+        MixsExtensions.map_to_interface_name([interface_name])
         if interface_name
         else parsed_submission_object.get("mixs_extensions", [])
     )

--- a/src/nmdc_metadata_suggestor_ai_tool/system_prompt.py
+++ b/src/nmdc_metadata_suggestor_ai_tool/system_prompt.py
@@ -14,7 +14,7 @@ REASONING FIELD RULES:
 - No tautology: Do NOT use generic, domain-only justifications (e.g., "pH is a fundamental soil property") unless you also cite supporting input text. Reasons must tie back to the submission input.
 - No schema names: Do not reference  schema packages or technical labels (e.g., "AirInterface"). Reasons should reference only the user's provided input (abstract, filenames, or explicit additional info).
 - Omit weak suggestions: If there is no explicit text and no strong, well-justified inference, DO NOT include the field in the output. Do not add fields solely because they exist in the NMDC schema.
-- Only suggest terms as they relate to the included schema interfaces. Ie do not site `water temp mentioned in abstract` as reasoning for a soil interface field. Suggestions should be in relation to schema interfaces. 
+- Only suggest terms as they relate to the included schema interfaces. I.e. do not cite `water temp mentioned in abstract` as reasoning for a soil interface field. Suggestions should be in relation to schema interfaces.
 
 VALUE FIELD RULES:
 Only populate `value` when the input contains the specific value (exact text). Otherwise, leave `value` as an empty string "".

--- a/tests/test_recommendation_pipeline.py
+++ b/tests/test_recommendation_pipeline.py
@@ -94,6 +94,106 @@ def test_run_recommendation_pipeline_raises_for_invalid_output_schema(
         )
 
 
+_VALID_RESPONSE = (
+    '{"metadata_fields":[{"field_name":"env_broad_scale",'
+    '"reason":"Required for submission.","value":"soil"}]}'
+)
+
+
+def _spy_on_schema_context(monkeypatch: pytest.MonkeyPatch) -> dict:
+    """Stub the network abstract lookup and capture the class names that the
+    pipeline hands to ``format_multi_interface_context``.
+
+    Note: the other pipeline tests stub ``format_multi_interface_context`` via
+    ``_stub_common_inputs`` and discard its argument, so they never observe what
+    ``interface_name`` resolves to. This spy records that argument instead.
+    """
+    monkeypatch.setattr(
+        build_submission_context,
+        "get_doi_description_or_abstract",
+        lambda **_: SimpleNamespace(context="Test abstract", publication_urls=[]),
+    )
+    captured: dict = {}
+
+    def _record(self: object, class_names: list[str]) -> str:
+        captured["class_names"] = class_names
+        return "schema context"
+
+    monkeypatch.setattr(
+        recommendation_pipeline.SchemaContextBuilder,
+        "format_multi_interface_context",
+        _record,
+    )
+    return captured
+
+
+def test_interface_name_resolves_to_interface_class_names(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """A supplied ``interface_name`` must resolve to the same interface-class
+    vocabulary as the submission-object path (``"soil"`` -> ``["SoilInterface"]``).
+
+    Reveals the bug: the pipeline does ``list(interface_name)``, which splits the
+    string into characters (``["s", "o", "i", "l"]``) instead of normalizing it.
+    """
+    captured = _spy_on_schema_context(monkeypatch)
+    client = _FakeLLMClient(response=_VALID_RESPONSE)
+
+    recommendation_pipeline.run_recommendation_pipeline(
+        submission_object=load_sample_submission_object(),
+        llm_client=client,
+        interface_name="soil",
+    )
+
+    assert captured["class_names"] == ["SoilInterface"]
+
+
+def test_interface_name_accepts_interface_class_name_form(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """The parser was extended to accept enum names too, so passing the class
+    name directly should also resolve to ``["SoilInterface"]``.
+
+    Reveals the bug: ``list("SoilInterface")`` yields a list of 13 characters.
+    """
+    captured = _spy_on_schema_context(monkeypatch)
+    client = _FakeLLMClient(response=_VALID_RESPONSE)
+
+    recommendation_pipeline.run_recommendation_pipeline(
+        submission_object=load_sample_submission_object(),
+        llm_client=client,
+        interface_name="SoilInterface",
+    )
+
+    assert captured["class_names"] == ["SoilInterface"]
+
+
+def test_interface_name_does_not_crash_schema_context_builder(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """End-to-end guard: supplying ``interface_name`` must not raise.
+
+    ``format_multi_interface_context`` is deliberately NOT stubbed here, so the
+    real ``SchemaContextBuilder`` runs. Reveals the bug: the character-split feeds
+    invalid class names into the builder, which raises
+    ``ValueError: Unknown class: s``.
+    """
+    monkeypatch.setattr(
+        build_submission_context,
+        "get_doi_description_or_abstract",
+        lambda **_: SimpleNamespace(context="Test abstract", publication_urls=[]),
+    )
+    client = _FakeLLMClient(response=_VALID_RESPONSE)
+
+    result = recommendation_pipeline.run_recommendation_pipeline(
+        submission_object=load_sample_submission_object(),
+        llm_client=client,
+        interface_name="soil",
+    )
+
+    assert result.metadata_fields[0].field_name == "env_broad_scale"
+
+
 def test_run_recommendation_pipeline(requires_credentials: None) -> None:
     start = time.time_ns()
     sample_submission_object = load_sample_submission_object()

--- a/tests/test_recommendation_pipeline.py
+++ b/tests/test_recommendation_pipeline.py
@@ -194,6 +194,48 @@ def test_interface_name_does_not_crash_schema_context_builder(
     assert result.metadata_fields[0].field_name == "env_broad_scale"
 
 
+def test_interface_name_overrides_submission_package(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """A supplied ``interface_name`` takes precedence over the submission's own
+    package. The sample submission is a soil package; passing ``"water"`` should
+    drive the schema context to ``["WaterInterface"]``, not the submission's soil.
+
+    Reveals the bug: ``list("water")`` yields ``["w", "a", "t", "e", "r"]``.
+    """
+    captured = _spy_on_schema_context(monkeypatch)
+    client = _FakeLLMClient(response=_VALID_RESPONSE)
+
+    recommendation_pipeline.run_recommendation_pipeline(
+        submission_object=load_sample_submission_object(),
+        llm_client=client,
+        interface_name="water",
+    )
+
+    assert captured["class_names"] == ["WaterInterface"]
+
+
+@pytest.mark.parametrize("interface_name", [None, ""])
+def test_absent_interface_name_falls_back_to_submission_package(
+    monkeypatch: pytest.MonkeyPatch, interface_name: str | None
+) -> None:
+    """When ``interface_name`` is absent or empty, the pipeline falls back to the
+    interfaces parsed from the submission object (soil for the sample fixture).
+
+    Passes today; a regression guard so the fix preserves the fallback path.
+    """
+    captured = _spy_on_schema_context(monkeypatch)
+    client = _FakeLLMClient(response=_VALID_RESPONSE)
+
+    recommendation_pipeline.run_recommendation_pipeline(
+        submission_object=load_sample_submission_object(),
+        llm_client=client,
+        interface_name=interface_name,
+    )
+
+    assert captured["class_names"] == ["SoilInterface"]
+
+
 def test_run_recommendation_pipeline(requires_credentials: None) -> None:
     start = time.time_ns()
     sample_submission_object = load_sample_submission_object()

--- a/tests/test_submission_parser.py
+++ b/tests/test_submission_parser.py
@@ -1,7 +1,13 @@
 import json
+import logging
 from pathlib import Path
 
-from nmdc_metadata_suggestor_ai_tool.utils.submission_parser import get_submission_fields
+import pytest
+
+from nmdc_metadata_suggestor_ai_tool.utils.submission_parser import (
+    MixsExtensions,
+    get_submission_fields,
+)
 
 FIXTURES_DIR = Path(__file__).parent / "fixtures"
 
@@ -36,3 +42,37 @@ def test_get_submission_fields_extracts_protocol_metadata_from_fixture() -> None
     ]
     assert len(result["protocol_descs"]) == 5
     assert result["mixs_extensions"] == ["SoilInterface"]
+
+
+def test_map_to_interface_name_accepts_enum_value() -> None:
+    """A package value such as "soil" maps to its interface class name."""
+    assert MixsExtensions.map_to_interface_name(["soil"]) == ["SoilInterface"]
+
+
+def test_map_to_interface_name_accepts_enum_name() -> None:
+    """A class name such as "SoilInterface" is accepted and returned as-is.
+
+    This is the new capability #93 added to support an explicit interface tab.
+    """
+    assert MixsExtensions.map_to_interface_name(["SoilInterface"]) == ["SoilInterface"]
+
+
+def test_map_to_interface_name_skips_empty_strings() -> None:
+    """Empty (or falsy) entries are skipped, not mapped."""
+    assert MixsExtensions.map_to_interface_name(["", "soil"]) == ["SoilInterface"]
+
+
+def test_map_to_interface_name_skips_and_warns_on_unrecognized(
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    """Unrecognized entries are dropped and logged at WARNING level."""
+    with caplog.at_level(logging.WARNING):
+        result = MixsExtensions.map_to_interface_name(["frobnicate"])
+    assert result == []
+    assert "Unrecognized MIxS extension 'frobnicate'" in caplog.text
+
+
+def test_map_to_interface_name_preserves_order_across_mixed_forms() -> None:
+    """A mix of value and name forms is normalized to class names in input order."""
+    result = MixsExtensions.map_to_interface_name(["water", "SoilInterface", "air"])
+    assert result == ["WaterInterface", "SoilInterface", "AirInterface"]


### PR DESCRIPTION
Stacked on #93. Fixes a crash in the new `interface_name` path and adds the test coverage #93 is missing.

## The bug

`run_recommendation_pipeline` resolved `interface_name` with `list(interface_name)`. Because `interface_name` is a string, that split it into characters: `"soil"` became `["s", "o", "i", "l"]`. `SchemaContextBuilder.format_multi_interface_context` then looked each character up as an interface class and raised `ValueError: Unknown class: s`, so the feature crashed whenever `interface_name` was supplied. The existing pipeline tests did not catch it because they stub `format_multi_interface_context` and discard its argument.

## The fix

Resolve `interface_name` through `MixsExtensions.map_to_interface_name([interface_name])`, which is what #93 already extended that method to accept. It normalizes both a package value (`"soil"`) and a class name (`"SoilInterface"`) to `["SoilInterface"]`. Also corrects the docstring (`interface_tab` -> `interface_name`), a comment typo, and `Ie do not site` -> `I.e. do not cite` in the system prompt.

## Tests added

Pipeline (`tests/test_recommendation_pipeline.py`):
- `"soil"` resolves to `["SoilInterface"]`
- `"SoilInterface"` resolves to `["SoilInterface"]`
- supplying `interface_name` does not raise (runs the real `SchemaContextBuilder`)
- a supplied `interface_name` overrides the submission's own package
- absent or empty `interface_name` falls back to the submission's interfaces

Parser (`tests/test_submission_parser.py`), direct coverage for `MixsExtensions.map_to_interface_name`, which #93 rewrote and which had no tests: value form, name form, empty-string skip, unrecognized skip plus warning, order preservation.

## How to take this

Merge this PR into the `73-suggester-...` branch (or cherry-pick the commits). #93 then carries the fix and tests.

## On CI

CI does not run on this PR. `.github/workflows/ci.yml` triggers only on pull requests whose base is `main`; this PR is based on the feature branch, so no checks are reported. That is expected. Locally the full suite passes (ruff, ruff format, mypy, pytest: 200 passed, 8 skipped).
