### PR TITLE
Add live CBORG provider integration tests

### DIFF
--- a/tests/fixtures/llm_auth.py
+++ b/tests/fixtures/llm_auth.py
@@ -1,4 +1,4 @@
-"""Shared pytest fixtures for tests requiring LLM credentials (GCP or PNNL)."""
+"""Shared pytest fixtures for tests requiring LLM credentials (GCP, PNNL, or CBORG)."""
 
 import os
 from pathlib import Path
@@ -38,3 +38,16 @@ def requires_credentials(has_gcp_credentials: bool, has_pnnl_credentials: bool) 
     """Skip the current test when neither GCP nor PNNL credentials are available."""
     if not has_gcp_credentials and not has_pnnl_credentials:
         pytest.skip("Neither GCP nor PNNL credentials available")
+
+
+@pytest.fixture(scope="session")
+def has_cborg_credentials() -> bool:
+    """Return whether CBORG credentials are configured via API key and base URL."""
+    return bool(os.environ.get("CBORG_KEY") and os.environ.get("CBORG_BASE_URL"))
+
+
+@pytest.fixture
+def requires_cborg(has_cborg_credentials: bool) -> None:
+    """Skip the current test when CBORG credentials are not available."""
+    if not has_cborg_credentials:
+        pytest.skip("CBORG credentials (CBORG_KEY, CBORG_BASE_URL) not available")

--- a/tests/test_cborg_integration.py
+++ b/tests/test_cborg_integration.py
@@ -11,9 +11,9 @@ Run them with:
 Credentials (``CBORG_KEY``, ``CBORG_BASE_URL``) are read from the environment,
 which ``llm_client`` populates from ``.env`` via ``load_dotenv()`` at import.
 
-The model is set explicitly. The built-in default model is Gemini-specific
-(``gemini-2.5-flash``), which CBORG does not recognize, so provider tests must
-name a model CBORG serves. Override with the ``CBORG_TEST_MODEL`` env var.
+The model is set explicitly so the test pins a specific CBORG-served model
+instead of depending on the pipeline default, keeping the assertion
+deterministic. Override with the ``CBORG_TEST_MODEL`` env var.
 """
 
 import json

--- a/tests/test_cborg_integration.py
+++ b/tests/test_cborg_integration.py
@@ -11,9 +11,8 @@ Run them with:
 Credentials (``CBORG_KEY``, ``CBORG_BASE_URL``) are read from the environment,
 which ``llm_client`` populates from ``.env`` via ``load_dotenv()`` at import.
 
-The model is set explicitly so the test pins a specific CBORG-served model
-instead of depending on the pipeline default, keeping the assertion
-deterministic. Override with the ``CBORG_TEST_MODEL`` env var.
+The model defaults to the same model as the production CBORG path. Override it
+with ``CBORG_TEST_MODEL`` to exercise another CBORG-served model explicitly.
 """
 
 import json
@@ -23,12 +22,13 @@ from pathlib import Path
 import pytest
 from openai import OpenAI
 
-from nmdc_metadata_suggestor_ai_tool.llm_client import LLMClient
+from nmdc_metadata_suggestor_ai_tool.llm_client import DEFAULT_GEMINI_MODEL, LLMClient
 from nmdc_metadata_suggestor_ai_tool.recommendation_pipeline import run_recommendation_pipeline
 
 FIXTURES_DIR = Path(__file__).parent / "fixtures"
 INTEGRATION_TIMEOUT = 120  # seconds
-CBORG_MODEL = os.environ.get("CBORG_TEST_MODEL", "gpt-4o-mini")
+INTEGRATION_MAX_TOKENS = 8192
+CBORG_MODEL = os.environ.get("CBORG_TEST_MODEL", DEFAULT_GEMINI_MODEL)
 
 
 def _load_fixture(filename: str) -> dict:
@@ -38,21 +38,22 @@ def _load_fixture(filename: str) -> dict:
 
 @pytest.mark.integration
 @pytest.mark.timeout(INTEGRATION_TIMEOUT)
-def test_cborg_api_reachable(requires_cborg: None) -> None:
-    """The CBORG endpoint responds to an authenticated request with the .env key.
+def test_cborg_responses_api_reachable(requires_cborg: None) -> None:
+    """The CBORG Responses API accepts an authenticated request with the .env key.
 
-    This is the low-level check: credentials and base URL are valid and the
-    gateway is reachable, independent of the recommendation pipeline.
+    This is the low-level check: credentials, base URL, and configured model
+    work through the same endpoint used by the recommendation pipeline.
     """
     client = OpenAI(
         api_key=os.environ["CBORG_KEY"],
         base_url=os.environ["CBORG_BASE_URL"],
     )
-    model_ids = [m.id for m in client.models.list().data]
-    assert model_ids, "CBORG returned no models"
-    assert CBORG_MODEL in model_ids, (
-        f"{CBORG_MODEL} not offered by CBORG; available sample: {model_ids[:8]}"
+    response = client.responses.create(
+        model=CBORG_MODEL,
+        input="Reply with a short acknowledgement.",
+        max_output_tokens=16,
     )
+    assert response.output_text.strip(), "CBORG returned no response text"
 
 
 @pytest.mark.integration
@@ -61,15 +62,17 @@ def test_cborg_pipeline_returns_field_guidance(requires_cborg: None) -> None:
     """The recommendation pipeline runs end to end over CBORG and returns valid output.
 
     This is the field-guidance task: each suggestion names a metadata field the
-    submitter should populate, with a reason. It does not fill in a value, so
-    this asserts field_name and reason are present and does NOT assert a
-    non-empty value (confirmed empty for this task with both gpt-4o-mini and
-    gpt-5).
+    submitter should populate, with a reason. Suggested values are optional for
+    this task, so the test does not require them.
     """
     submission = _load_fixture("full_submission.json")
     client = LLMClient(access_provider="cborg", model=CBORG_MODEL)
 
-    result = run_recommendation_pipeline(submission_object=submission, llm_client=client)
+    result = run_recommendation_pipeline(
+        submission_object=submission,
+        llm_client=client,
+        max_tokens=INTEGRATION_MAX_TOKENS,
+    )
 
     assert result.metadata_fields, "Expected at least one metadata field suggestion"
     for field in result.metadata_fields:

--- a/tests/test_cborg_integration.py
+++ b/tests/test_cborg_integration.py
@@ -1,0 +1,80 @@
+"""Integration tests for the CBORG access provider.
+
+CBORG is LBL's OpenAI- and Anthropic-compatible LiteLLM gateway. These tests
+hit the real endpoint, so they are marked ``integration`` and excluded from
+normal CI (see ``addopts = "-m 'not integration'"`` in pyproject.toml). They
+skip when CBORG credentials are absent.
+
+Run them with:
+    uv run pytest -m integration tests/test_cborg_integration.py
+
+Credentials (``CBORG_KEY``, ``CBORG_BASE_URL``) are read from the environment,
+which ``llm_client`` populates from ``.env`` via ``load_dotenv()`` at import.
+
+The model is set explicitly. The built-in default model is Gemini-specific
+(``gemini-2.5-flash``), which CBORG does not recognize, so provider tests must
+name a model CBORG serves. Override with the ``CBORG_TEST_MODEL`` env var.
+"""
+
+import json
+import os
+from pathlib import Path
+
+import pytest
+from openai import OpenAI
+
+from nmdc_metadata_suggestor_ai_tool.llm_client import LLMClient
+from nmdc_metadata_suggestor_ai_tool.recommendation_pipeline import run_recommendation_pipeline
+
+FIXTURES_DIR = Path(__file__).parent / "fixtures"
+INTEGRATION_TIMEOUT = 120  # seconds
+CBORG_MODEL = os.environ.get("CBORG_TEST_MODEL", "gpt-4o-mini")
+
+
+def _load_fixture(filename: str) -> dict:
+    with (FIXTURES_DIR / filename).open() as f:
+        return json.load(f)
+
+
+@pytest.mark.integration
+@pytest.mark.timeout(INTEGRATION_TIMEOUT)
+def test_cborg_api_reachable(requires_cborg: None) -> None:
+    """The CBORG endpoint responds to an authenticated request with the .env key.
+
+    This is the low-level check: credentials and base URL are valid and the
+    gateway is reachable, independent of the recommendation pipeline.
+    """
+    client = OpenAI(
+        api_key=os.environ["CBORG_KEY"],
+        base_url=os.environ["CBORG_BASE_URL"],
+    )
+    model_ids = [m.id for m in client.models.list().data]
+    assert model_ids, "CBORG returned no models"
+    assert CBORG_MODEL in model_ids, (
+        f"{CBORG_MODEL} not offered by CBORG; available sample: {model_ids[:8]}"
+    )
+
+
+@pytest.mark.integration
+@pytest.mark.timeout(INTEGRATION_TIMEOUT)
+def test_cborg_pipeline_returns_field_guidance(requires_cborg: None) -> None:
+    """The recommendation pipeline runs end to end over CBORG and returns valid output.
+
+    This is the field-guidance task: each suggestion names a metadata field the
+    submitter should populate, with a reason. It does not fill in a value, so
+    this asserts field_name and reason are present and does NOT assert a
+    non-empty value (confirmed empty for this task with both gpt-4o-mini and
+    gpt-5).
+    """
+    submission = _load_fixture("full_submission.json")
+    client = LLMClient(access_provider="cborg", model=CBORG_MODEL)
+
+    result = run_recommendation_pipeline(submission_object=submission, llm_client=client)
+
+    assert result.metadata_fields, "Expected at least one metadata field suggestion"
+    for field in result.metadata_fields:
+        assert field.field_name, "field_name must not be empty"
+        assert field.reason, "reason must not be empty"
+
+    assert result.model == CBORG_MODEL
+    assert result.access_provider == "cborg"


### PR DESCRIPTION
Adds opt-in live integration coverage for the CBORG access provider, following the repository's existing provider-test pattern.

## Behavior

- Adds a low-level smoke test that calls the same OpenAI-compatible Responses API endpoint used by the application. This catches authentication, routing, model, and endpoint failures without relying on the separate model-catalog endpoint.
- Adds an end-to-end recommendation-pipeline test that validates non-empty field names and reasons plus the resolved model and access-provider metadata.
- Defaults to the same Gemini model as the production CBORG path while preserving CBORG_TEST_MODEL as an explicit override.
- Caps the integration test at 8,192 output tokens so the test is bounded and does not inherit the provider-wide 128,000-token default.
- Adds credential-aware CBORG pytest fixtures. The tests remain excluded from normal CI and skip when CBORG credentials are absent.

## Rationale

The previous model-catalog smoke check could pass even when the Responses API used by production failed. Live verification demonstrated that exact failure mode: gpt-4o-mini remained advertised while real requests failed because its upstream credits were exhausted. The production-default gemini-2.5-flash completed both the corrected smoke request and the full recommendation fixture.

CBORG requires LBLnet or an authorized IP, so these tests are intentionally not added to the public weekly GitHub Actions workflow.

## Validation

- uv run ruff check
- uv run mypy src
- uv run pytest -q — 257 passed, 59 deselected
- uv run pytest -m integration tests/test_cborg_integration.py -q — 2 passed in 3.05s against live CBORG

## Documentation impact

The test module documents credentials, manual invocation, model override behavior, and why the test is excluded from normal CI. No user-facing application behavior changes.

## Follow-up

Live testing also showed that one provider-wide CBORG output-token default is unsafe across backing models with different context limits. That production policy is intentionally separate in #147.

Closes #61.