### PR TITLE
Fix malformed ENVO CURIE in env_triad system prompt example

### DIFF
--- a/src/nmdc_metadata_suggestor_ai_tool/system_prompt.py
+++ b/src/nmdc_metadata_suggestor_ai_tool/system_prompt.py
@@ -42,7 +42,7 @@ Output schema:
 env_triad_prompt = """
 Use the provided information to suggest values for the following three metadata fields: env_broad_scale, env_local_scale, and env_medium.
 
-- env_broad_scale: This field should capture the broad environmental category of the sample (e.g., "anthropogenic terrestrial biome [ENVO:01000219]", "freshwater lake biome [ENVO:01000252]", "marine biome ENVO:00000447]").
+- env_broad_scale: This field should capture the broad environmental category of the sample (e.g., "anthropogenic terrestrial biome [ENVO:01000219]", "freshwater lake biome [ENVO:01000252]", "marine biome [ENVO:00000447]").
 - env_local_scale: This field should capture the more specific local environment of the sample (e.g., "agricultural field [ENVO:00000114]", "rhizosphere [ENVO:00005801]", "aquifer [ENVO:00012408]").
 - env_medium: This field should capture the medium in which the sample was collected ("soil [ENVO:00001998]", "acidic water [ENVO:01000358]", "alluvial paddy field soil [ENVO:00005759]").
 


### PR DESCRIPTION
The env_broad_scale example in the env_triad system prompt listed `marine biome ENVO:00000447]` with a missing opening bracket, so the one example meant to model the `label [CURIE]` format doesn't follow it. A malformed few-shot example teaches the model to emit malformed CURIEs. `ENVO:00000447` is the correct id for marine biome (verified against ENVO).

One-character fix. Closes #119.