### PR TITLE
Mark real api tests as integration and auto mark to prevent drift

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -2,6 +2,9 @@
 
 import sys
 from pathlib import Path
+from typing import Generator
+
+import pytest
 
 # Make `tests/` importable so fixture plugins under tests/fixtures can be loaded.
 tests_path = Path(__file__).parent
@@ -12,3 +15,11 @@ pytest_plugins = ["fixtures.llm_auth"]
 # Add src directory to Python path for imports
 src_path = Path(__file__).parent.parent / "src"
 sys.path.insert(0, str(src_path))
+
+
+def pytest_collection_modifyitems(items: list[pytest.Item]) -> None:
+    """Auto-mark any test that uses requires_credentials as integration."""
+    integration = pytest.mark.integration
+    for item in items:
+        if "requires_credentials" in getattr(item, "fixturenames", []):
+            item.add_marker(integration, append=False)

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -2,7 +2,6 @@
 
 import sys
 from pathlib import Path
-from typing import Generator
 
 import pytest
 

--- a/tests/test_agentic.py
+++ b/tests/test_agentic.py
@@ -50,7 +50,6 @@ def _assert_valid_output(result: object) -> LLMOutput:
 # ---------------------------------------------------------------------------
 
 
-@pytest.mark.integration
 @pytest.mark.timeout(INTEGRATION_TIMEOUT)
 def test_agentic_metadata_pipeline_with_full_submission(requires_credentials: None) -> None:
     """Full submission object → metadata field suggestions via agentic()."""
@@ -64,7 +63,6 @@ def test_agentic_metadata_pipeline_with_full_submission(requires_credentials: No
     assert fields_with_values > 0, "Expected at least one field with a non-empty value"
 
 
-@pytest.mark.integration
 @pytest.mark.timeout(INTEGRATION_TIMEOUT)
 def test_agentic_metadata_pipeline_with_test_submission(requires_credentials: None) -> None:
     """test_submission.json fixture → metadata field suggestions via agentic()."""
@@ -80,7 +78,6 @@ def test_agentic_metadata_pipeline_with_test_submission(requires_credentials: No
 # ---------------------------------------------------------------------------
 
 
-@pytest.mark.integration
 @pytest.mark.timeout(INTEGRATION_TIMEOUT)
 def test_agentic_env_triad_single_biosample(requires_credentials: None) -> None:
     """Single ETL-shaped biosample → env triad suggestions via agentic()."""
@@ -103,7 +100,6 @@ def test_agentic_env_triad_single_biosample(requires_credentials: None) -> None:
     )
 
 
-@pytest.mark.integration
 @pytest.mark.timeout(INTEGRATION_TIMEOUT)
 def test_agentic_env_triad_with_study_context(requires_credentials: None) -> None:
     """ETL biosamples + study context → env triad suggestions via agentic()."""
@@ -132,7 +128,6 @@ def test_agentic_env_triad_with_study_context(requires_credentials: None) -> Non
 # ---------------------------------------------------------------------------
 
 
-@pytest.mark.integration
 @pytest.mark.timeout(INTEGRATION_TIMEOUT * 2)
 def test_agentic_session_resumption(requires_credentials: None) -> None:
     """Start a session, then resume it with a follow-up message."""

--- a/tests/test_agentic.py
+++ b/tests/test_agentic.py
@@ -10,11 +10,11 @@ from pathlib import Path
 
 import pytest
 
-pytestmark = pytest.mark.integration
-
 from nmdc_metadata_suggestor_ai_tool.llm_client import ConversationManager, LLMClient
 from nmdc_metadata_suggestor_ai_tool.models.llm_output import LLMOutput
 from nmdc_metadata_suggestor_ai_tool.system_prompt import env_triad_prompt, system_prompt
+
+pytestmark = pytest.mark.integration
 
 FIXTURES = Path(__file__).parent / "fixtures"
 INTEGRATION_TIMEOUT = 180  # seconds

--- a/tests/test_agentic.py
+++ b/tests/test_agentic.py
@@ -10,6 +10,8 @@ from pathlib import Path
 
 import pytest
 
+pytestmark = pytest.mark.integration
+
 from nmdc_metadata_suggestor_ai_tool.llm_client import ConversationManager, LLMClient
 from nmdc_metadata_suggestor_ai_tool.models.llm_output import LLMOutput
 from nmdc_metadata_suggestor_ai_tool.system_prompt import env_triad_prompt, system_prompt

--- a/tests/test_env_triad_recommendation.py
+++ b/tests/test_env_triad_recommendation.py
@@ -1,7 +1,11 @@
 from pathlib import Path
 
+import pytest
+
 from nmdc_metadata_suggestor_ai_tool import env_triad_recommendation
 from nmdc_metadata_suggestor_ai_tool.llm_client import LLMClient
+
+pytestmark = pytest.mark.integration
 
 
 def load_sample_submission_object() -> dict:

--- a/tests/test_vertexai_integration.py
+++ b/tests/test_vertexai_integration.py
@@ -27,7 +27,6 @@ def _load_fixture(filename: str) -> dict:
         return json.load(f)
 
 
-@pytest.mark.integration
 @pytest.mark.timeout(INTEGRATION_TIMEOUT)
 def test_pipeline_returns_valid_llm_output() -> None:
     """Run the full recommendation pipeline and validate the LLMOutput model."""
@@ -54,7 +53,6 @@ def test_pipeline_returns_valid_llm_output() -> None:
     assert result.access_provider == "gcp"
 
 
-@pytest.mark.integration
 @pytest.mark.timeout(INTEGRATION_TIMEOUT)
 def test_gemini_conversation_with_schema_context() -> None:
     """Verify the Gemini model can process schema context and return valid JSON."""

--- a/tests/test_vertexai_integration.py
+++ b/tests/test_vertexai_integration.py
@@ -10,11 +10,11 @@ from pathlib import Path
 
 import pytest
 
-pytestmark = pytest.mark.integration
-
 from nmdc_metadata_suggestor_ai_tool.llm_client import ConversationManager, LLMClient
 from nmdc_metadata_suggestor_ai_tool.recommendation_pipeline import run_recommendation_pipeline
 from nmdc_metadata_suggestor_ai_tool.utils.utils import validate_output
+
+pytestmark = pytest.mark.integration
 
 FIXTURES_DIR = Path(__file__).parent / "fixtures"
 

--- a/tests/test_vertexai_integration.py
+++ b/tests/test_vertexai_integration.py
@@ -10,6 +10,8 @@ from pathlib import Path
 
 import pytest
 
+pytestmark = pytest.mark.integration
+
 from nmdc_metadata_suggestor_ai_tool.llm_client import ConversationManager, LLMClient
 from nmdc_metadata_suggestor_ai_tool.recommendation_pipeline import run_recommendation_pipeline
 from nmdc_metadata_suggestor_ai_tool.utils.utils import validate_output


### PR DESCRIPTION
Add integration markers and function to prevent integration marking drift. 