### PR TITLE
Weekly integration test failing

### DIFF
--- a/.github/workflows/weekly-integration-test.yml
+++ b/.github/workflows/weekly-integration-test.yml
@@ -33,4 +33,7 @@ jobs:
         run: uv sync
 
       - name: Run VertexAI integration tests
+        env:
+          NMDC_HTTP_RETRY_ATTEMPTS: "1"
+          NMDC_HTTP_MAX_RETRY_DELAY_SECONDS: "5"
         run: uv run pytest tests/test_vertexai_integration.py -m integration -v

--- a/tests/test_vertexai_integration.py
+++ b/tests/test_vertexai_integration.py
@@ -12,9 +12,8 @@ import pytest
 
 from nmdc_metadata_suggestor_ai_tool.llm_client import ConversationManager, LLMClient
 from nmdc_metadata_suggestor_ai_tool.recommendation_pipeline import run_recommendation_pipeline
-from nmdc_metadata_suggestor_ai_tool.utils.utils import validate_output
 from nmdc_metadata_suggestor_ai_tool.system_prompt import env_triad_prompt
-
+from nmdc_metadata_suggestor_ai_tool.utils.utils import validate_output
 
 pytestmark = pytest.mark.integration
 

--- a/tests/test_vertexai_integration.py
+++ b/tests/test_vertexai_integration.py
@@ -13,6 +13,8 @@ import pytest
 from nmdc_metadata_suggestor_ai_tool.llm_client import ConversationManager, LLMClient
 from nmdc_metadata_suggestor_ai_tool.recommendation_pipeline import run_recommendation_pipeline
 from nmdc_metadata_suggestor_ai_tool.utils.utils import validate_output
+from nmdc_metadata_suggestor_ai_tool.system_prompt import env_triad_prompt
+
 
 pytestmark = pytest.mark.integration
 
@@ -57,7 +59,7 @@ def test_pipeline_returns_valid_llm_output() -> None:
 def test_gemini_conversation_with_schema_context() -> None:
     """Verify the Gemini model can process schema context and return valid JSON."""
     client = LLMClient(access_provider="gcp")
-    conversation = ConversationManager(llm_client=client)
+    conversation = ConversationManager(llm_client=client, system_prompt=env_triad_prompt)
     conversation.add_schema_context('{"fields": [{"name": "env_broad_scale", "type": "string"}]}')
     conversation.add_message(
         text=(


### PR DESCRIPTION
Fix the weekly integration test:

- credentials json was not in the github action secrets
- needed to add system prompt param to ConversationManager
- Restrict retry attempts to conform to the timeout limit. 