### PR TITLE
Create Skill to enforce DOI copywrite for AI use

### DIFF
--- a/.claude/skills/build-study-context/SKILL.md
+++ b/.claude/skills/build-study-context/SKILL.md
@@ -46,8 +46,11 @@ result = get_doi_description_or_abstract(
 )
 ```
 
-- Add `result.context` to the evidence texts (label it with the DOI value)
-- Accumulate all `result.publication_urls` into a list
+Then apply the **doi-copyright-check** skill to the returned metadata:
+
+- If `verdict == "allowed"`: add `result.context` to the evidence texts (label it with the DOI value)
+- If `verdict == "not_allowed"` or `"uncertain"`: **exclude** the content; add the DOI to a `skipped_dois` list and log a warning
+- Accumulate all `result.publication_urls` into a list regardless of verdict (URLs themselves are not restricted content)
 
 ### 3 — Fetch PDF content
 

--- a/.claude/skills/doi-copyright-check/SKILL.md
+++ b/.claude/skills/doi-copyright-check/SKILL.md
@@ -27,16 +27,22 @@ Evaluate the license string from the DOI metadata (typically in `result.context`
 
 | License | AI Context Use Allowed? | Condition |
 |---|---|---|
-| `CC BY 4.0` / `CC-BY` | Yes | Attribute the original authors and source |
-| `CC BY-SA 4.0` | Yes | Attribute; any derived work must carry the same license |
-| `CC BY-ND 4.0` | Yes (read-only context) | Attribute; do not modify or redistribute the content itself |
-| `CC BY-NC 4.0` | Yes, PNNL internal use only | Non-commercial; attribute |
+| `CC BY 4.0` / `CC-BY` / `CC BY 3.0` | Yes | Attribute the original authors and source |
+| `CC BY-SA 4.0` / `CC BY-SA 3.0` | Yes | Attribute; any derived work must carry the same license |
+| `CC BY-ND 4.0` / `CC BY-ND 3.0` | Yes (verbatim context only) | Attribute; do not modify or redistribute the content itself — see ND note below |
+| `CC BY-NC 4.0` / `CC BY-NC 3.0` | Yes, PNNL internal use only | Non-commercial; attribute |
 | `CC BY-NC-SA` / `CC BY-NC-ND` | Yes, PNNL internal use only | Non-commercial; apply SA/ND constraints above |
 | `CC0` / Public Domain | Yes | No attribution required |
 | All rights reserved / no CC license found | **No** — skip this content | Cannot use without explicit publisher permission |
 | License unclear / not found | **Uncertain** — flag for review | Do not use; surface the DOI for manual check |
 
 **Rule of thumb:** If the license starts with `CC BY` or is `CC0`, you can use the content. If there is no CC license, do not use it.
+
+> **Note on CC BY-ND ("No Derivatives"):** Passing text verbatim to an LLM as prompt context does not obviously create a derivative work, which is the basis for treating it as allowed. However, this interpretation is not settled law. If the content will be excerpted, paraphrased, or transformed in the LLM output, treat it as **Uncertain** and flag for manual review instead.
+
+> **Note on CC BY-NC and commercial use:** NC licenses permit internal research use at a non-profit or government lab (like PNNL). If any part of the pipeline or its outputs supports a commercial product or revenue-generating activity, the NC restriction may be triggered — escalate to the PNNL library team.
+
+> **Note on version differences (3.0 vs 4.0):** For practical purposes, CC 3.0 and 4.0 licenses of the same type are treated identically here. CC 4.0 introduced minor improvements (e.g., explicit database rights) but the core permissions are the same.
 
 ---
 
@@ -47,6 +53,7 @@ Evaluate the license string from the DOI metadata (typically in `result.context`
 Check these locations in order:
 
 1. A `license` or `rights` field in the DOI source metadata (DataCite, CrossRef, OpenAlex all return this).
+   - License values may be a URL (e.g., `https://creativecommons.org/licenses/by/4.0/`) rather than a plain string. Parse the URL path to extract the license type: `by` → CC BY, `by-sa` → CC BY-SA, `by-nd` → CC BY-ND, `by-nc` → CC BY-NC, etc. The version number is the last path segment (e.g., `/4.0/`).
 2. The abstract/description text itself — publishers often embed the CC notice in the full text (look for phrases like `"licensed under a Creative Commons"`, `"CC BY"`, `"http://creativecommons.org/licenses/"`).
 3. If neither is found, treat as **Uncertain**.
 

--- a/.claude/skills/doi-copyright-check/SKILL.md
+++ b/.claude/skills/doi-copyright-check/SKILL.md
@@ -1,0 +1,86 @@
+---
+name: doi-copyright-check
+description: Use this skill to check whether a DOI's publication content may be used as AI context (not training). Returns a verdict based on the Creative Commons license reported by the DOI source metadata.
+---
+
+# DOI Copyright Check Skill
+
+Use this skill **after** the **doi-ingestion** skill has returned metadata for a DOI, to determine whether the publication content may be used as AI inference context.
+
+> **Scope:** This check covers using content as **context passed to an LLM at inference time** (e.g., summarization, metadata suggestion). It does NOT cover model training, fine-tuning, or retention of the content — those uses carry stricter obligations not addressed here.
+
+---
+
+## Background
+
+Open Access (OA) status and AI usability are **not the same thing**:
+
+- A paper being OA (author paid for open access) does not automatically grant AI usage rights.
+- The API or index that surfaced the DOI (OpenAlex, DataCite, etc.) having permissive API terms does **not** transfer to the publication content itself.
+- The relevant check is the **Creative Commons (CC) license on the article**, not the OA flag or the API terms.
+
+---
+
+## Decision Rules
+
+Evaluate the license string from the DOI metadata (typically in `result.context`, the abstract, or a license field returned by the source):
+
+| License | AI Context Use Allowed? | Condition |
+|---|---|---|
+| `CC BY 4.0` / `CC-BY` | Yes | Attribute the original authors and source |
+| `CC BY-SA 4.0` | Yes | Attribute; any derived work must carry the same license |
+| `CC BY-ND 4.0` | Yes (read-only context) | Attribute; do not modify or redistribute the content itself |
+| `CC BY-NC 4.0` | Yes, PNNL internal use only | Non-commercial; attribute |
+| `CC BY-NC-SA` / `CC BY-NC-ND` | Yes, PNNL internal use only | Non-commercial; apply SA/ND constraints above |
+| `CC0` / Public Domain | Yes | No attribution required |
+| All rights reserved / no CC license found | **No** — skip this content | Cannot use without explicit publisher permission |
+| License unclear / not found | **Uncertain** — flag for review | Do not use; surface the DOI for manual check |
+
+**Rule of thumb:** If the license starts with `CC BY` or is `CC0`, you can use the content. If there is no CC license, do not use it.
+
+---
+
+## Steps
+
+### 1 — Locate the license
+
+Check these locations in order:
+
+1. A `license` or `rights` field in the DOI source metadata (DataCite, CrossRef, OpenAlex all return this).
+2. The abstract/description text itself — publishers often embed the CC notice in the full text (look for phrases like `"licensed under a Creative Commons"`, `"CC BY"`, `"http://creativecommons.org/licenses/"`).
+3. If neither is found, treat as **Uncertain**.
+
+### 2 — Apply the decision table above
+
+Map the found license string to the Allowed/No/Uncertain verdict.
+
+### 3 — Return a structured result
+
+```python
+{
+    "doi": "<doi value>",
+    "license_found": "<license string or None>",
+    "verdict": "allowed" | "not_allowed" | "uncertain",
+    "condition": "<attribution or other constraint, or None>",
+    "note": "<short human-readable explanation>"
+}
+```
+
+---
+
+## Integration with build-study-context
+
+After calling **doi-ingestion** for each DOI:
+
+1. Run this check on the returned metadata.
+2. If `verdict == "allowed"`: include `result.context` in `context_texts` as normal.
+3. If `verdict == "not_allowed"`: **exclude** the content; log a warning with the DOI and reason.
+4. If `verdict == "uncertain"`: **exclude** the content; surface the DOI in a `skipped_dois` list for the caller to review.
+
+---
+
+## Important caveats
+
+- **Author self-use:** An author using their own non-OA paper may have retained rights under their individual copyright agreement, but this tool cannot verify that. Treat non-CC content as `not_allowed` regardless.
+- **This is not legal advice.** The legal landscape around AI and copyright is actively evolving. When in doubt, escalate to the PNNL library team before using restricted content.
+- **Training vs. context:** These rules apply only to inference-time context. Using content to train or fine-tune a model, or retaining a copy of the content, requires a separate and stricter review.

--- a/.claude/skills/doi-copyright-check/SKILL.md
+++ b/.claude/skills/doi-copyright-check/SKILL.md
@@ -30,8 +30,8 @@ Evaluate the license string from the DOI metadata (typically in `result.context`
 | `CC BY 4.0` / `CC-BY` / `CC BY 3.0` | Yes | Attribute the original authors and source |
 | `CC BY-SA 4.0` / `CC BY-SA 3.0` | Yes | Attribute; any derived work must carry the same license |
 | `CC BY-ND 4.0` / `CC BY-ND 3.0` | Yes (verbatim context only) | Attribute; do not modify or redistribute the content itself — see ND note below |
-| `CC BY-NC 4.0` / `CC BY-NC 3.0` | Yes, PNNL internal use only | Non-commercial; attribute |
-| `CC BY-NC-SA` / `CC BY-NC-ND` | Yes, PNNL internal use only | Non-commercial; apply SA/ND constraints above |
+| `CC BY-NC 4.0` / `CC BY-NC 3.0` | Yes, non-commercial use only | Non-commercial; attribute; verify your use case is non-commercial |
+| `CC BY-NC-SA` / `CC BY-NC-ND` | Yes, non-commercial use only | Non-commercial; apply SA/ND constraints above |
 | `CC0` / Public Domain | Yes | No attribution required |
 | All rights reserved / no CC license found | **No** — skip this content | Cannot use without explicit publisher permission |
 | License unclear / not found | **Uncertain** — flag for review | Do not use; surface the DOI for manual check |
@@ -40,7 +40,7 @@ Evaluate the license string from the DOI metadata (typically in `result.context`
 
 > **Note on CC BY-ND ("No Derivatives"):** Passing text verbatim to an LLM as prompt context does not obviously create a derivative work, which is the basis for treating it as allowed. However, this interpretation is not settled law. If the content will be excerpted, paraphrased, or transformed in the LLM output, treat it as **Uncertain** and flag for manual review instead.
 
-> **Note on CC BY-NC and commercial use:** NC licenses permit internal research use at a non-profit or government lab (like PNNL). If any part of the pipeline or its outputs supports a commercial product or revenue-generating activity, the NC restriction may be triggered — escalate to the PNNL library team.
+> **Note on CC BY-NC and commercial use:** NC licenses permit non-commercial use (research, academic, government, non-profit contexts). If any part of the pipeline or its outputs supports a commercial product or revenue-generating activity, the NC restriction may be triggered — verify with your institution's library or legal team before proceeding.
 
 > **Note on version differences (3.0 vs 4.0):** For practical purposes, CC 3.0 and 4.0 licenses of the same type are treated identically here. CC 4.0 introduced minor improvements (e.g., explicit database rights) but the core permissions are the same.
 
@@ -89,5 +89,5 @@ After calling **doi-ingestion** for each DOI:
 ## Important caveats
 
 - **Author self-use:** An author using their own non-OA paper may have retained rights under their individual copyright agreement, but this tool cannot verify that. Treat non-CC content as `not_allowed` regardless.
-- **This is not legal advice.** The legal landscape around AI and copyright is actively evolving. When in doubt, escalate to the PNNL library team before using restricted content.
+- **This is not legal advice.** The legal landscape around AI and copyright is actively evolving. When in doubt, consult your institution's library or legal team before using restricted content.
 - **Training vs. context:** These rules apply only to inference-time context. Using content to train or fine-tune a model, or retaining a copy of the content, requires a separate and stricter review.

--- a/.claude/skills/doi-copyright-check/SKILL.md
+++ b/.claude/skills/doi-copyright-check/SKILL.md
@@ -62,7 +62,7 @@ Map the found license string to the Allowed/No/Uncertain verdict.
     "license_found": "<license string or None>",
     "verdict": "allowed" | "not_allowed" | "uncertain",
     "condition": "<attribution or other constraint, or None>",
-    "note": "<short human-readable explanation>"
+    "note": "<short human-readable explanation>",
 }
 ```
 

--- a/.claude/skills/metadata-suggestion-pipeline/SKILL.md
+++ b/.claude/skills/metadata-suggestion-pipeline/SKILL.md
@@ -25,12 +25,15 @@ Use the **submission-parser** skill to extract structured fields (DOIs, descript
 
 ## Step 2 — Build study context
 
-Use the **build-study-context** skill with the parsed submission to:
-- Assemble base text (description, notes, study name, protocol info)
-- Fetch DOI abstracts
-- Download PDFs
+Use the **build-study-context** skill with the parsed submission. That skill handles all of the following — do not skip or short-circuit it:
 
-This yields `context_texts` (list of strings) and `pdf_paths` (list of temp file paths) to use as evidence.
+1. Assemble base text (description, notes, study name, protocol info)
+2. For each DOI: call **doi-ingestion**, then **doi-copyright-check** on the returned metadata
+   - `verdict == "allowed"` → include the abstract in `context_texts`
+   - `verdict == "not_allowed"` or `"uncertain"` → **exclude** the abstract; add the DOI to `skipped_dois`
+3. Download PDFs via **pdf-ingestion**
+
+This yields `context_texts` (list of strings — base text plus copyright-cleared abstracts) and `pdf_paths` to use as evidence in Step 4.
 
 ---
 
@@ -75,15 +78,21 @@ Return a JSON object matching `LLMOutput`:
   "metadata_fields": [
     {
       "id": null,
-      "field_name": "relevant_protocols",
-      "value": "https://doi.org/10.17504/protocols.io.xxx",
-      "reason": "Protocol DOI explicitly listed in multiOmicsForm.mbProtocols (protocol description)."
+      "field_name": "geo_loc_name",
+      "value": "USA: California",
+      "reason": "'collected from surface soils across California grassland sites' (abstract)."
     },
     {
       "id": null,
-      "field_name": "ecosystem_type",
-      "value": "",
-      "reason": "'peatland CO2, CH4 porewater production' (abstract) strongly implies a bog or fen ecosystem, but no exact NMDC term is explicitly named."
+      "field_name": "ecosystem_category",
+      "value": "Soil",
+      "reason": "'soil metagenomes from 189 globally distributed sites' (abstract)."
+    },
+    {
+      "id": null,
+      "field_name": "relevant_protocols",
+      "value": "https://doi.org/10.17504/protocols.io.xxx",
+      "reason": "Protocol DOI explicitly listed in multiOmicsForm.mbProtocols (submission data)."
     }
   ]
 }

--- a/.env.example
+++ b/.env.example
@@ -12,6 +12,11 @@ LANGFUSE_TRACING_ENVIRONMENT=local
 # local = anyone's local environment
 # unknown = the fallback value
 
+
+### Agent Configuration (optional) ###
+# set CLAUDE_AGENT_BYPASS_PERMISSIONS=true to disable the SDK's permission guardrails. This allows Claude to run bash commands and WebSearch. Default is `false`
+CLAUDE_AGENT_BYPASS_PERMISSIONS=false
+
 ### LLM Access ###
 # PNNL AI Incubator API credentials
 AI_INCUBATOR_KEY=key

--- a/src/nmdc_metadata_suggestor_ai_tool/doi_ingestion/doi_copyright.py
+++ b/src/nmdc_metadata_suggestor_ai_tool/doi_ingestion/doi_copyright.py
@@ -46,9 +46,9 @@ _CC_SLUG_VERDICTS: dict[str, tuple[Verdict, str]] = {
     "by": ("allowed", "Attribute the original authors and source"),
     "by-sa": ("allowed", "Attribute; any derived work must carry the same license"),
     "by-nd": ("allowed", "Attribute; use verbatim only — do not modify or redistribute"),
-    "by-nc": ("not_allowed", "Non-commercial only; PNNL internal use — verify before including"),
-    "by-nc-sa": ("not_allowed", "Non-commercial; apply SA constraints — PNNL internal use only"),
-    "by-nc-nd": ("not_allowed", "Non-commercial; apply ND constraints — PNNL internal use only"),
+    "by-nc": ("allowed", "Non-commercial use only — verify your use case is non-commercial"),
+    "by-nc-sa": ("allowed", "Non-commercial use only; derived works must carry the same license"),
+    "by-nc-nd": ("allowed", "Non-commercial use only; use verbatim only — do not modify or redistribute"),
 }
 
 # Patterns that indicate a CC license string (non-URL form)
@@ -141,8 +141,8 @@ def check_doi_copyright(
             if nc:
                 note = (
                     f"License {slug.upper()} is non-commercial. "
-                    "Allowed for PNNL internal research use only; "
-                    "verify no commercial activity is involved."
+                    "Allowed for non-commercial use only; "
+                    "verify your use case is non-commercial before including."
                 )
             elif nd:
                 note = (

--- a/src/nmdc_metadata_suggestor_ai_tool/doi_ingestion/doi_copyright.py
+++ b/src/nmdc_metadata_suggestor_ai_tool/doi_ingestion/doi_copyright.py
@@ -48,7 +48,10 @@ _CC_SLUG_VERDICTS: dict[str, tuple[Verdict, str]] = {
     "by-nd": ("allowed", "Attribute; use verbatim only — do not modify or redistribute"),
     "by-nc": ("allowed", "Non-commercial use only — verify your use case is non-commercial"),
     "by-nc-sa": ("allowed", "Non-commercial use only; derived works must carry the same license"),
-    "by-nc-nd": ("allowed", "Non-commercial use only; use verbatim only — do not modify or redistribute"),
+    "by-nc-nd": (
+        "allowed",
+        "Non-commercial use only; use verbatim only — do not modify or redistribute",
+    ),
 }
 
 # Patterns that indicate a CC license string (non-URL form)

--- a/src/nmdc_metadata_suggestor_ai_tool/doi_ingestion/doi_copyright.py
+++ b/src/nmdc_metadata_suggestor_ai_tool/doi_ingestion/doi_copyright.py
@@ -1,0 +1,183 @@
+"""DOI copyright / license check for AI inference-time context use.
+
+Implements the decision logic from ``.claude/skills/doi-copyright-check/SKILL.md``.
+Determines whether a publication's content may be passed to an LLM as inference
+context (NOT training).  Returns a structured verdict so callers can include or
+exclude content automatically.
+"""
+
+from __future__ import annotations
+
+import re
+from typing import Literal
+
+from pydantic import BaseModel
+
+# ---------------------------------------------------------------------------
+# Verdict type
+# ---------------------------------------------------------------------------
+
+Verdict = Literal["allowed", "not_allowed", "uncertain"]
+
+
+class CopyrightCheckResult(BaseModel):
+    """Verdict for one DOI's AI inference-context usability."""
+
+    doi: str
+    license_found: str | None
+    verdict: Verdict
+    condition: str | None = None
+    note: str
+
+
+# ---------------------------------------------------------------------------
+# License normalisation helpers
+# ---------------------------------------------------------------------------
+
+# Regex to parse Creative Commons URL paths, e.g.
+# https://creativecommons.org/licenses/by-nc/4.0/
+_CC_URL_RE = re.compile(
+    r"creativecommons\.org/licenses/([a-z-]+)/(\d+\.\d+)",
+    re.IGNORECASE,
+)
+
+# Map normalised CC slugs to (verdict, condition)
+_CC_SLUG_VERDICTS: dict[str, tuple[Verdict, str]] = {
+    "by": ("allowed", "Attribute the original authors and source"),
+    "by-sa": ("allowed", "Attribute; any derived work must carry the same license"),
+    "by-nd": ("allowed", "Attribute; use verbatim only — do not modify or redistribute"),
+    "by-nc": ("not_allowed", "Non-commercial only; PNNL internal use — verify before including"),
+    "by-nc-sa": ("not_allowed", "Non-commercial; apply SA constraints — PNNL internal use only"),
+    "by-nc-nd": ("not_allowed", "Non-commercial; apply ND constraints — PNNL internal use only"),
+}
+
+# Patterns that indicate a CC license string (non-URL form)
+_CC_STRING_RE = re.compile(
+    r"cc[-\s]?(by(?:[-\s](?:nc|sa|nd))*(?:[-\s](?:nc|sa|nd))*)\s*(?:\d+\.\d+)?",
+    re.IGNORECASE,
+)
+
+# CC0 / public domain
+_CC0_RE = re.compile(r"cc0|public\s+domain|cc\s+zero|publicdomain/zero", re.IGNORECASE)
+
+
+def _normalise_license(raw: str) -> str | None:
+    """Return a normalised CC slug (e.g. ``"by"``, ``"by-nc"``) or ``None``.
+
+    Handles both URL form (``https://creativecommons.org/licenses/by/4.0/``)
+    and plain-text forms (``"CC BY 4.0"``, ``"CC-BY-NC"``).
+    """
+    if _CC0_RE.search(raw):
+        return "cc0"
+
+    # URL form
+    url_match = _CC_URL_RE.search(raw)
+    if url_match:
+        return url_match.group(1).lower()
+
+    # Plain-text form — strip leading "cc" / "cc-" / "cc by" etc.
+    text_match = _CC_STRING_RE.search(raw)
+    if text_match:
+        slug = re.sub(r"[\s]+", "-", text_match.group(1).strip()).lower()
+        return slug
+
+    return None
+
+
+# ---------------------------------------------------------------------------
+# Public API
+# ---------------------------------------------------------------------------
+
+
+def check_doi_copyright(
+    doi: str,
+    license_string: str | None,
+    *,
+    context_text: str | None = None,
+) -> CopyrightCheckResult:
+    """Check whether a DOI's content may be used as LLM inference context.
+
+    Parameters
+    ----------
+    doi:
+        The DOI being checked.
+    license_string:
+        The license field returned by the DOI source (DataCite, CrossRef,
+        OpenAlex).  May be a URL or a plain string.  Pass ``None`` if the
+        metadata contained no license field.
+    context_text:
+        Optional abstract / description text.  When ``license_string`` is
+        absent the function searches ``context_text`` for an embedded CC
+        notice (publishers often include one in the abstract).
+
+    Returns
+    -------
+    CopyrightCheckResult
+    """
+    candidates: list[str] = []
+    if license_string:
+        candidates.append(license_string)
+    if context_text:
+        candidates.append(context_text)
+
+    for candidate in candidates:
+        slug = _normalise_license(candidate)
+        if slug is None:
+            continue
+
+        if slug == "cc0":
+            return CopyrightCheckResult(
+                doi=doi,
+                license_found=candidate,
+                verdict="allowed",
+                condition="No attribution required",
+                note="CC0 / Public Domain — unrestricted inference-context use.",
+            )
+
+        if slug in _CC_SLUG_VERDICTS:
+            verdict, condition = _CC_SLUG_VERDICTS[slug]
+            nc = "nc" in slug
+            nd = "nd" in slug
+            if nc:
+                note = (
+                    f"License {slug.upper()} is non-commercial. "
+                    "Allowed for PNNL internal research use only; "
+                    "verify no commercial activity is involved."
+                )
+            elif nd:
+                note = (
+                    f"License {slug.upper()} prohibits derivatives. "
+                    "Passing content verbatim as LLM context is generally non-derivative, "
+                    "but this is an interpretive call — flag if content will be paraphrased."
+                )
+            else:
+                note = f"License {slug.upper()} permits inference-context use with attribution."
+            return CopyrightCheckResult(
+                doi=doi,
+                license_found=candidate,
+                verdict=verdict,
+                condition=condition,
+                note=note,
+            )
+
+    # No CC license found
+    if candidates:
+        return CopyrightCheckResult(
+            doi=doi,
+            license_found=license_string,
+            verdict="not_allowed",
+            condition=None,
+            note=(
+                "No Creative Commons license detected. "
+                "Cannot use content without explicit publisher permission."
+            ),
+        )
+
+    # No license information at all
+    return CopyrightCheckResult(
+        doi=doi,
+        license_found=None,
+        verdict="uncertain",
+        condition=None,
+        note="License not found in metadata or abstract text. Flag for manual review.",
+    )

--- a/src/nmdc_metadata_suggestor_ai_tool/llm_client.py
+++ b/src/nmdc_metadata_suggestor_ai_tool/llm_client.py
@@ -381,7 +381,7 @@ class ConversationManager:
             model=model,
             system_prompt=orchestrator_prompt,
             output_format={"type": "json_schema", "schema": LLMOutput.model_json_schema()},
-            permission_mode="bypassPermissions",
+            permission_mode=cast(Any, AGENT_PERMISSION_MODE),
         )
 
         if message is None:

--- a/src/nmdc_metadata_suggestor_ai_tool/llm_client.py
+++ b/src/nmdc_metadata_suggestor_ai_tool/llm_client.py
@@ -358,7 +358,11 @@ class ConversationManager:
         If None, starts a new session.
 
         """
-        model = DEFAULT_CLAUDE_MODEL if self.llm_client.access_provider == "gcp" else self.llm_client.model
+        model = (
+            DEFAULT_CLAUDE_MODEL
+            if self.llm_client.access_provider == "gcp"
+            else self.llm_client.model
+        )
         # set env variable to enable Claude Agent SDK to pick up GCP credentials
         # Claude Agent SDK requires a Claude model, not a Gemini model, even on Vertex AI
         options = ClaudeAgentOptions(

--- a/src/nmdc_metadata_suggestor_ai_tool/llm_client.py
+++ b/src/nmdc_metadata_suggestor_ai_tool/llm_client.py
@@ -23,6 +23,7 @@ from nmdc_metadata_suggestor_ai_tool.models.llm_output import LLMOutput
 from nmdc_metadata_suggestor_ai_tool.system_prompt import orchestrator_prompt
 from nmdc_metadata_suggestor_ai_tool.tracing import (
     langfuse_client,
+    log_assistant_message,
     observe,
     propagate_attributes,
 )
@@ -394,11 +395,7 @@ class ConversationManager:
                     session_id = event.data["session_id"]
                 elif isinstance(event, AssistantMessage):
                     print(f"Assistant: {event.content}")
-                    if langfuse_client is not None:
-                        langfuse_client.create_event(
-                            name="assistant_message",
-                            output=event.content,
-                        )
+                    log_assistant_message(event.content)
                 elif isinstance(event, ResultMessage):
                     result = self.unwrap_structured_output(event.structured_output)
             if langfuse_client is not None:
@@ -419,11 +416,7 @@ class ConversationManager:
                         session_id = event.data["session_id"]
                     elif isinstance(event, AssistantMessage):
                         print(f"Assistant: {event.content}")
-                        if langfuse_client is not None:
-                            langfuse_client.create_event(
-                                name="assistant_message",
-                                output=event.content,
-                            )
+                        log_assistant_message(event.content)
                     elif isinstance(event, ResultMessage):
                         result = self.unwrap_structured_output(event.structured_output)
             if langfuse_client is not None:

--- a/src/nmdc_metadata_suggestor_ai_tool/llm_client.py
+++ b/src/nmdc_metadata_suggestor_ai_tool/llm_client.py
@@ -366,6 +366,7 @@ class ConversationManager:
             model=model,
             system_prompt=orchestrator_prompt,
             output_format={"type": "json_schema", "schema": LLMOutput.model_json_schema()},
+            permission_mode="bypassPermissions",
         )
 
         if message is None:
@@ -389,6 +390,11 @@ class ConversationManager:
                     session_id = event.data["session_id"]
                 elif isinstance(event, AssistantMessage):
                     print(f"Assistant: {event.content}")
+                    if langfuse_client is not None:
+                        langfuse_client.create_event(
+                            name="assistant_message",
+                            output=event.content,
+                        )
                 elif isinstance(event, ResultMessage):
                     result = self.unwrap_structured_output(event.structured_output)
             if langfuse_client is not None:
@@ -407,6 +413,13 @@ class ConversationManager:
                 ):
                     if isinstance(event, SystemMessage) and event.subtype == "init":
                         session_id = event.data["session_id"]
+                    elif isinstance(event, AssistantMessage):
+                        print(f"Assistant: {event.content}")
+                        if langfuse_client is not None:
+                            langfuse_client.create_event(
+                                name="assistant_message",
+                                output=event.content,
+                            )
                     elif isinstance(event, ResultMessage):
                         result = self.unwrap_structured_output(event.structured_output)
             if langfuse_client is not None:

--- a/src/nmdc_metadata_suggestor_ai_tool/llm_client.py
+++ b/src/nmdc_metadata_suggestor_ai_tool/llm_client.py
@@ -32,6 +32,16 @@ load_dotenv()
 
 DEFAULT_GCP_REGION = "us-east5"
 
+# Set CLAUDE_AGENT_BYPASS_PERMISSIONS=true to disable the SDK's permission guardrails.
+# Disabling allows Claude to run bash commands and WebSearch,
+# which improves preformance but increases security risks.
+# Defaults to "default" which requires explicit permissions for shell commands and WebSearch.
+AGENT_PERMISSION_MODE = (
+    "bypassPermissions"
+    if os.environ.get("CLAUDE_AGENT_BYPASS_PERMISSIONS", "") == "true"
+    else "default"
+)
+
 
 GEMINI_MODELS = [
     "gemini-2.5-pro",

--- a/src/nmdc_metadata_suggestor_ai_tool/system_prompt.py
+++ b/src/nmdc_metadata_suggestor_ai_tool/system_prompt.py
@@ -43,6 +43,8 @@ orchestrator_prompt = """
 Use the nmdc-metadata-suggestor skill to process the input and return a merged LLMOutput JSON.
 
 CRITICAL EXECUTION RULES:
+- Do not run shell commands, execute code, or read/write files outside of the skills you have been given. Only use tools as directed by skill instructions.
+- Do not run WebSearch or any external API calls. Only use the skills provided.
 - Do NOT call StructuredOutput until ALL pipeline steps are fully complete.
 - Call StructuredOutput exactly once — as the very last action — with the final LLMOutput JSON (metadata_fields list).
 - If the stop hook fires mid-pipeline, ignore it and continue executing the remaining steps before calling StructuredOutput.

--- a/src/nmdc_metadata_suggestor_ai_tool/tracing.py
+++ b/src/nmdc_metadata_suggestor_ai_tool/tracing.py
@@ -108,10 +108,19 @@ if not langfuse_enabled:
         return decorator
 
 
-def log_assistant_message(content: str) -> None:
-    """Emit a Langfuse event for one AssistantMessage turn (no-op when tracing is off)."""
-    if langfuse_client is not None:
-        langfuse_client.create_event(name="assistant_message", output=content)
+def log_assistant_message(content: Any) -> None:
+    """Emit a Langfuse event for one AssistantMessage turn (no-op when tracing is off).
+
+    Accepts either a plain string or a list of content blocks (TextBlock etc.) as
+    returned by the Claude Agent SDK's AssistantMessage.content.
+    """
+    if langfuse_client is None:
+        return
+    if isinstance(content, list):
+        text = " ".join(b.text for b in content if hasattr(b, "text"))
+    else:
+        text = content
+    langfuse_client.create_event(name="assistant_message", output=text)
 
 
 def flush() -> None:

--- a/src/nmdc_metadata_suggestor_ai_tool/tracing.py
+++ b/src/nmdc_metadata_suggestor_ai_tool/tracing.py
@@ -108,6 +108,12 @@ if not langfuse_enabled:
         return decorator
 
 
+def log_assistant_message(content: str) -> None:
+    """Emit a Langfuse event for one AssistantMessage turn (no-op when tracing is off)."""
+    if langfuse_client is not None:
+        langfuse_client.create_event(name="assistant_message", output=content)
+
+
 def flush() -> None:
     """Flush pending Langfuse events (call before process exit in short-lived scripts)."""
     if langfuse_enabled and langfuse_client is not None:

--- a/tests/fixtures/submission_cc_by_publication.json
+++ b/tests/fixtures/submission_cc_by_publication.json
@@ -1,0 +1,160 @@
+{
+  "metadata_submission": {
+    "packageName": ["soil"],
+    "studyForm": {
+      "studyName": "Genomic Catalog of Earth's Microbiomes — Soil Biosample Study",
+      "piName": "Test Researcher",
+      "piEmail": "test.researcher@example.org",
+      "piOrcid": "0000-0000-0000-0001",
+      "description":"",
+      "notes": "Samples stored at -80C prior to DNA extraction.",
+      "publicationDois": [
+        {
+          "value": "10.1038/s41564-020-00861-0",
+          "provider": "crossref"
+        }
+      ],
+      "dataDois": null,
+      "GOLDStudyId": "",
+      "NCBIBioProjectId": ""
+    },
+    "multiOmicsForm": {
+      "award": "CSP",
+      "awardDois": [],
+      "JGIStudyId": "",
+      "omicsProcessingTypes": ["mg"],
+      "mpProtocols": null,
+      "mbProtocols": null,
+      "mbGcProtocols": null,
+      "lipProtocols": null,
+      "nomProtocols": null,
+      "nomLcProtocols": null
+    },
+    "sampleData": {
+      "soil_data": [
+        {
+          "samp_name": "GCEM-soil-001",
+          "lat_lon": "37.87 -122.26",
+          "geo_loc_name": "USA: California, Berkeley",
+          "collection_date": "2019-06-15",
+          "depth": "0 - 0.1",
+          "elev": 180,
+          "growth_facil": "field",
+          "analysis_type": ["metagenomics"],
+          "store_cond": "frozen -80C"
+        },
+        {
+          "samp_name": "GCEM-soil-002",
+          "lat_lon": "-3.46 -62.22",
+          "geo_loc_name": "Brazil: Amazonas, Manaus",
+          "collection_date": "2019-03-10",
+          "depth": "0 - 0.1",
+          "elev": 92,
+          "env_broad_scale": "tropical moist broadleaf forest biome [ENVO:01000228]",
+          "growth_facil": "field",
+          "analysis_type": ["metagenomics"],
+          "store_cond": "frozen -80C"
+        },
+        {
+          "samp_name": "GCEM-soil-003",
+          "lat_lon": "68.35 18.82",
+          "geo_loc_name": "Sweden: Lapland, Abisko",
+          "collection_date": "2019-07-22",
+          "depth": "0 - 0.1",
+          "elev": 385,
+          "env_medium": "Arctic soil [ENVO:00005741]",
+          "growth_facil": "field",
+          "analysis_type": ["metagenomics"],
+          "store_cond": "frozen -80C"
+        },
+        {
+          "samp_name": "GCEM-soil-004",
+          "lat_lon": "-33.87 151.21",
+          "geo_loc_name": "Australia: New South Wales, Sydney",
+          "collection_date": "2019-10-05",
+          "depth": "0 - 0.1",
+          "elev": 39,
+          "growth_facil": "field",
+          "analysis_type": ["metagenomics"],
+          "store_cond": "frozen -80C"
+        },
+        {
+          "samp_name": "GCEM-soil-005",
+          "lat_lon": "51.45 -1.03",
+          "geo_loc_name": "United Kingdom: England, Oxfordshire",
+          "collection_date": "2019-05-18",
+          "depth": "0 - 0.1",
+          "elev": 57,
+          "env_local_scale": "meadow [ENVO:00000108]",
+          "growth_facil": "field",
+          "analysis_type": ["metagenomics"],
+          "store_cond": "frozen -80C"
+        },
+        {
+          "samp_name": "GCEM-soil-006",
+          "lat_lon": "23.11 79.47",
+          "geo_loc_name": "India: Madhya Pradesh, Jabalpur",
+          "collection_date": "2019-01-30",
+          "depth": "0 - 0.15",
+          "elev": 393,
+          "env_medium": "soil [ENVO:00001998]",
+          "growth_facil": "field",
+          "analysis_type": ["metagenomics"],
+          "store_cond": "frozen -80C"
+        },
+        {
+          "samp_name": "GCEM-soil-007",
+          "lat_lon": "-34.61 -58.38",
+          "geo_loc_name": "Argentina: Buenos Aires",
+          "collection_date": "2019-09-12",
+          "depth": "0 - 0.1",
+          "elev": 25,
+          "growth_facil": "field",
+          "analysis_type": ["metagenomics"],
+          "store_cond": "frozen -80C"
+        },
+        {
+          "samp_name": "GCEM-soil-008",
+          "lat_lon": "36.21 37.16",
+          "geo_loc_name": "Turkey: Aleppo, Gaziantep",
+          "collection_date": "2019-04-03",
+          "depth": "0 - 0.1",
+          "elev": 855,
+          "growth_facil": "field",
+          "analysis_type": ["metagenomics"],
+          "store_cond": "frozen -80C"
+        },
+        {
+          "samp_name": "GCEM-soil-009",
+          "lat_lon": "0.34 32.58",
+          "geo_loc_name": "Uganda: Kampala",
+          "collection_date": "2019-08-07",
+          "depth": "0 - 0.1",
+          "elev": 1160,
+          "env_broad_scale": "tropical moist broadleaf forest biome [ENVO:01000228]",
+          "growth_facil": "field",
+          "analysis_type": ["metagenomics"],
+          "store_cond": "frozen -80C"
+        },
+        {
+          "samp_name": "GCEM-soil-010",
+          "lat_lon": "43.70 -79.42",
+          "geo_loc_name": "Canada: Ontario, Toronto",
+          "collection_date": "2019-06-28",
+          "depth": "0 - 0.1",
+          "elev": 76,
+          "env_local_scale": "woodland area [ENVO:00000109]",
+          "growth_facil": "field",
+          "analysis_type": ["metagenomics"],
+          "store_cond": "frozen -80C"
+        }
+      ]
+    }
+  },
+  "status": "In Progress",
+  "source_client": "submission_portal",
+  "is_test_submission": true,
+  "id": "fixture-cc-by-0001",
+  "study_name": "Genomic Catalog of Earth's Microbiomes — Soil Biosample Study",
+  "templates": ["soil"]
+}

--- a/tests/fixtures/submission_restricted_publication.json
+++ b/tests/fixtures/submission_restricted_publication.json
@@ -1,0 +1,163 @@
+{
+  "metadata_submission": {
+    "packageName": ["soil"],
+    "studyForm": {
+      "studyName": "Global Soil Microbiome Survey — Paywalled Reference Publication",
+      "piName": "Test Researcher",
+      "piEmail": "test.researcher@example.org",
+      "piOrcid": "0000-0000-0000-0002",
+      "description": "Soil metagenomes sampled across 189 globally distributed sites covering major biome types. This study characterizes the biogeographic drivers of soil microbial community composition and function.",
+      "notes": "Reference publication is behind a paywall (Science, AAAS). No open-access license.",
+      "publicationDois": [
+        {
+          "value": "10.1126/science.aav2566",
+          "provider": "crossref"
+        }
+      ],
+      "dataDois": null,
+      "GOLDStudyId": "",
+      "NCBIBioProjectId": ""
+    },
+    "multiOmicsForm": {
+      "award": "CSP",
+      "awardDois": [],
+      "JGIStudyId": "",
+      "omicsProcessingTypes": ["mg"],
+      "mpProtocols": null,
+      "mbProtocols": null,
+      "mbGcProtocols": null,
+      "lipProtocols": null,
+      "nomProtocols": null,
+      "nomLcProtocols": null
+    },
+    "sampleData": {
+      "soil_data": [
+        {
+          "samp_name": "GSS-soil-001",
+          "lat_lon": "51.51 -0.13",
+          "geo_loc_name": "United Kingdom: England, London",
+          "collection_date": "2018-09-01",
+          "depth": "0 - 0.15",
+          "elev": 24,
+          "growth_facil": "field",
+          "analysis_type": ["metagenomics"],
+          "store_cond": "frozen -80C"
+        },
+        {
+          "samp_name": "GSS-soil-002",
+          "lat_lon": "44.80 20.46",
+          "geo_loc_name": "Serbia: Belgrade",
+          "collection_date": "2018-05-14",
+          "depth": "0 - 0.15",
+          "elev": 117,
+          "growth_facil": "field",
+          "analysis_type": ["metagenomics"],
+          "store_cond": "frozen -80C"
+        },
+        {
+          "samp_name": "GSS-soil-003",
+          "lat_lon": "-13.16 -72.54",
+          "geo_loc_name": "Peru: Cusco, Machu Picchu",
+          "collection_date": "2018-07-02",
+          "depth": "0 - 0.1",
+          "elev": 2430,
+          "env_broad_scale": "montane shrubland biome [ENVO:01000216]",
+          "env_local_scale": "mountainous area [ENVO:00000218]",
+          "env_medium": "soil [ENVO:00001998]",
+          "growth_facil": "field",
+          "analysis_type": ["metagenomics"],
+          "store_cond": "frozen -80C"
+        },
+        {
+          "samp_name": "GSS-soil-004",
+          "lat_lon": "30.05 31.25",
+          "geo_loc_name": "Egypt: Cairo",
+          "collection_date": "2018-02-20",
+          "depth": "0 - 0.1",
+          "elev": 23,
+          "env_broad_scale": "desert biome [ENVO:01000179]",
+          "growth_facil": "field",
+          "analysis_type": ["metagenomics"],
+          "store_cond": "frozen -80C"
+        },
+        {
+          "samp_name": "GSS-soil-005",
+          "lat_lon": "55.75 37.62",
+          "geo_loc_name": "Russia: Moscow Oblast",
+          "collection_date": "2018-06-10",
+          "depth": "0 - 0.15",
+          "elev": 144,
+          "growth_facil": "field",
+          "analysis_type": ["metagenomics"],
+          "store_cond": "frozen -80C"
+        },
+        {
+          "samp_name": "GSS-soil-006",
+          "lat_lon": "-26.20 28.04",
+          "geo_loc_name": "South Africa: Gauteng, Johannesburg",
+          "collection_date": "2018-11-05",
+          "depth": "0 - 0.1",
+          "elev": 1753,
+          "env_medium": "savanna soil [ENVO:00005750]",
+          "growth_facil": "field",
+          "analysis_type": ["metagenomics"],
+          "store_cond": "frozen -80C"
+        },
+        {
+          "samp_name": "GSS-soil-007",
+          "lat_lon": "35.69 139.69",
+          "geo_loc_name": "Japan: Tokyo",
+          "collection_date": "2018-04-22",
+          "depth": "0 - 0.1",
+          "elev": 40,
+          "env_local_scale": "woodland area [ENVO:00000109]",
+          "growth_facil": "field",
+          "analysis_type": ["metagenomics"],
+          "store_cond": "frozen -80C"
+        },
+        {
+          "samp_name": "GSS-soil-008",
+          "lat_lon": "45.42 -75.70",
+          "geo_loc_name": "Canada: Ontario, Ottawa",
+          "collection_date": "2018-08-16",
+          "depth": "0 - 0.15",
+          "elev": 70,
+          "env_broad_scale": "boreal forest biome [ENVO:01000250]",          
+          "growth_facil": "field",
+          "analysis_type": ["metagenomics"],
+          "store_cond": "frozen -80C"
+        },
+        {
+          "samp_name": "GSS-soil-009",
+          "lat_lon": "-1.29 36.82",
+          "geo_loc_name": "Kenya: Nairobi",
+          "collection_date": "2018-03-08",
+          "depth": "0 - 0.1",
+          "elev": 1661,
+          "env_broad_scale": "tropical savanna biome [ENVO:01000186]",
+          "growth_facil": "field",
+          "analysis_type": ["metagenomics"],
+          "store_cond": "frozen -80C"
+        },
+        {
+          "samp_name": "GSS-soil-010",
+          "lat_lon": "39.91 116.39",
+          "geo_loc_name": "China: Beijing",
+          "collection_date": "2018-10-19",
+          "depth": "0 - 0.15",
+          "elev": 43,
+          "env_local_scale": "woodland area [ENVO:00000109]",
+          "growth_facil": "field",
+          "analysis_type": ["metagenomics"],
+          "store_cond": "frozen -80C"
+        }
+      ]
+    }
+  },
+  "status": "In Progress",
+  "source_client": "submission_portal",
+  "is_test_submission": true,
+  "id": "fixture-restricted-0001",
+  "study_name": "Global Soil Microbiome Survey — Paywalled Reference Publication",
+  "templates": ["soil"]
+}

--- a/tests/test_doi_copyright.py
+++ b/tests/test_doi_copyright.py
@@ -42,6 +42,7 @@ def _load(filename: str) -> dict:
     with (FIXTURES / filename).open() as f:
         return json.load(f)
 
+
 _DOI_ALLOWED = "10.1038/s41564-020-00861-0"
 _DOI_RESTRICTED = "10.1126/science.aav2566"
 
@@ -280,8 +281,7 @@ def test_agent_uses_abstract_context_for_cc_by_publication(
     reasons = [f.reason.lower() for f in output.metadata_fields if f.reason]
     abstract_cited = any("abstract" in r for r in reasons)
     assert abstract_cited, (
-        "Expected at least one suggestion to cite the abstract as evidence. "
-        f"Got reasons: {reasons}"
+        f"Expected at least one suggestion to cite the abstract as evidence. Got reasons: {reasons}"
     )
 
 

--- a/tests/test_doi_copyright.py
+++ b/tests/test_doi_copyright.py
@@ -1,0 +1,328 @@
+"""Unit and integration tests for DOI copyright / license checking.
+
+Unit tests cover the decision rules in ``.claude/skills/doi-copyright-check/SKILL.md``:
+
+* CC BY family → allowed (with attribution condition)
+* CC BY-ND → allowed (verbatim only)
+* CC BY-NC family → not_allowed (non-commercial restriction)
+* CC0 / public domain → allowed (no attribution required)
+* All-rights-reserved / no CC license → not_allowed
+* No license info at all → uncertain
+* License supplied as a URL (e.g. creativecommons.org/licenses/by/4.0/)
+* License embedded in abstract text rather than a dedicated metadata field
+* Version variants (3.0 and 4.0 treated identically)
+
+Integration tests (``-m integration``, require GCP or PNNL credentials) run the
+full agentic pipeline against two fixture submissions:
+
+* ``submission_cc_by_publication.json`` — DOI 10.1038/s41564-020-00861-0 (CC BY 4.0).
+  The agent should use the abstract as context and produce evidence-cited suggestions.
+
+* ``submission_restricted_publication.json`` — DOI 10.1126/science.aav2566 (all rights
+  reserved, no CC license).  The agent should still suggest fields from submission
+  metadata alone, but must NOT cite the abstract as a source (it was excluded).
+"""
+
+import asyncio
+import json
+from pathlib import Path
+
+import pytest
+
+from nmdc_metadata_suggestor_ai_tool.doi_ingestion.doi_copyright import (
+    CopyrightCheckResult,
+    check_doi_copyright,
+)
+
+FIXTURES = Path(__file__).parent / "fixtures"
+INTEGRATION_TIMEOUT = 180  # seconds
+
+
+def _load(filename: str) -> dict:
+    with (FIXTURES / filename).open() as f:
+        return json.load(f)
+
+_DOI_ALLOWED = "10.1038/s41564-020-00861-0"
+_DOI_RESTRICTED = "10.1126/science.aav2566"
+
+
+# ---------------------------------------------------------------------------
+# Fixtures — real-world-style publications
+# ---------------------------------------------------------------------------
+
+
+@pytest.fixture
+def cc_by_publication() -> dict:
+    """Simulate metadata for a Nature Microbiology article published open-access CC BY 4.0.
+
+    Based on: 10.1038/s41564-020-00861-0
+    (Nayfach et al., "A genomic catalog of Earth's microbiomes", Nature Microbiology 2021)
+    License field as returned by CrossRef / OpenAlex.
+    """
+    return {
+        "doi": _DOI_ALLOWED,
+        "license": "https://creativecommons.org/licenses/by/4.0/",
+        "abstract": (
+            "Genomic sequencing has revolutionized our understanding of microbial "
+            "diversity across Earth's ecosystems. Here we present a catalog of "
+            "metagenome-assembled genomes spanning major habitats."
+        ),
+    }
+
+
+@pytest.fixture
+def all_rights_reserved_publication() -> dict:
+    """Simulate metadata for a Science article with no open-access license.
+
+    Based on: 10.1126/science.aav2566
+    (typical paywalled Science publication — no CC license in CrossRef metadata)
+    """
+    return {
+        "doi": _DOI_RESTRICTED,
+        "license": None,
+        "abstract": (
+            "Soil microbial communities play a key role in biogeochemical cycling. "
+            "This study characterizes metagenomes from 189 soil samples across "
+            "diverse biomes."
+        ),
+    }
+
+
+# ---------------------------------------------------------------------------
+# Core verdict tests — the two headline cases
+# ---------------------------------------------------------------------------
+
+
+def test_cc_by_publication_is_allowed(cc_by_publication: dict) -> None:
+    """A CC BY 4.0 publication must return verdict=allowed with an attribution condition."""
+    result = check_doi_copyright(
+        doi=cc_by_publication["doi"],
+        license_string=cc_by_publication["license"],
+        context_text=cc_by_publication["abstract"],
+    )
+    assert isinstance(result, CopyrightCheckResult)
+    assert result.verdict == "allowed"
+    assert result.license_found is not None
+    assert result.condition is not None
+    assert "ttrib" in result.condition  # "Attribute" or "attribution"
+
+
+def test_all_rights_reserved_publication_is_not_allowed(
+    all_rights_reserved_publication: dict,
+) -> None:
+    """A publication with no CC license must return verdict=not_allowed."""
+    result = check_doi_copyright(
+        doi=all_rights_reserved_publication["doi"],
+        license_string=all_rights_reserved_publication["license"],
+        context_text=all_rights_reserved_publication["abstract"],
+    )
+    assert isinstance(result, CopyrightCheckResult)
+    assert result.verdict == "not_allowed"
+    assert result.license_found is None
+
+
+# ---------------------------------------------------------------------------
+# Full decision-table coverage
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.parametrize(
+    "license_string,expected_verdict",
+    [
+        # CC BY variants — allowed
+        ("https://creativecommons.org/licenses/by/4.0/", "allowed"),
+        ("https://creativecommons.org/licenses/by/3.0/", "allowed"),
+        ("CC BY 4.0", "allowed"),
+        ("CC-BY", "allowed"),
+        # CC BY-SA — allowed
+        ("https://creativecommons.org/licenses/by-sa/4.0/", "allowed"),
+        ("CC BY-SA 3.0", "allowed"),
+        # CC BY-ND — allowed (verbatim-only caveat)
+        ("https://creativecommons.org/licenses/by-nd/4.0/", "allowed"),
+        ("CC BY-ND 3.0", "allowed"),
+        # CC BY-NC family — not_allowed (non-commercial restriction)
+        ("https://creativecommons.org/licenses/by-nc/4.0/", "not_allowed"),
+        ("CC BY-NC 4.0", "not_allowed"),
+        ("https://creativecommons.org/licenses/by-nc-sa/4.0/", "not_allowed"),
+        ("https://creativecommons.org/licenses/by-nc-nd/4.0/", "not_allowed"),
+        # CC0 / public domain — allowed
+        ("https://creativecommons.org/publicdomain/zero/1.0/", "allowed"),
+        ("CC0 1.0", "allowed"),
+        ("Public Domain", "allowed"),
+    ],
+)
+def test_license_decision_table(license_string: str, expected_verdict: str) -> None:
+    """Every entry in the SKILL.md decision table maps to the correct verdict."""
+    result = check_doi_copyright(doi="10.9999/test", license_string=license_string)
+    assert result.verdict == expected_verdict, (
+        f"License {license_string!r} → expected {expected_verdict!r}, got {result.verdict!r}"
+    )
+
+
+def test_no_license_info_at_all_is_uncertain() -> None:
+    """When neither metadata nor abstract text contains a license, verdict is uncertain."""
+    result = check_doi_copyright(
+        doi="10.9999/mystery",
+        license_string=None,
+        context_text=None,
+    )
+    assert result.verdict == "uncertain"
+    assert result.license_found is None
+
+
+def test_all_rights_reserved_string_is_not_allowed() -> None:
+    """A plain 'All rights reserved' license string with no CC marker is not_allowed."""
+    result = check_doi_copyright(
+        doi="10.9999/restricted",
+        license_string="All rights reserved",
+    )
+    assert result.verdict == "not_allowed"
+
+
+# ---------------------------------------------------------------------------
+# License URL parsing
+# ---------------------------------------------------------------------------
+
+
+def test_license_url_by_nc_parsed_correctly() -> None:
+    """CC BY-NC URL is parsed to the correct slug and returns not_allowed."""
+    result = check_doi_copyright(
+        doi="10.9999/nc-url",
+        license_string="http://creativecommons.org/licenses/by-nc/4.0/",
+    )
+    assert result.verdict == "not_allowed"
+    assert result.license_found is not None
+
+
+def test_license_url_by_sa_parsed_correctly() -> None:
+    """CC BY-SA URL is parsed to the correct slug and returns allowed."""
+    result = check_doi_copyright(
+        doi="10.9999/sa-url",
+        license_string="https://creativecommons.org/licenses/by-sa/3.0/",
+    )
+    assert result.verdict == "allowed"
+
+
+# ---------------------------------------------------------------------------
+# License embedded in abstract text
+# ---------------------------------------------------------------------------
+
+
+def test_cc_license_in_abstract_text_detected() -> None:
+    """A CC BY notice embedded in the abstract should be found when no metadata field exists."""
+    abstract = (
+        "This article is distributed under the terms of the Creative Commons "
+        "Attribution License (CC BY 4.0), which permits unrestricted use."
+    )
+    result = check_doi_copyright(
+        doi="10.9999/abstract-cc",
+        license_string=None,
+        context_text=abstract,
+    )
+    assert result.verdict == "allowed"
+    assert result.license_found == abstract
+
+
+# ---------------------------------------------------------------------------
+# Result structure
+# ---------------------------------------------------------------------------
+
+
+def test_result_has_required_fields() -> None:
+    """CopyrightCheckResult always carries doi, license_found, verdict, and note."""
+    result = check_doi_copyright(doi="10.9999/fields", license_string="CC BY 4.0")
+    assert result.doi == "10.9999/fields"
+    assert result.verdict in {"allowed", "not_allowed", "uncertain"}
+    assert isinstance(result.note, str)
+    assert len(result.note) > 0
+
+
+# ---------------------------------------------------------------------------
+# Integration tests — full agentic pipeline, require LLM credentials
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.integration
+@pytest.mark.timeout(INTEGRATION_TIMEOUT)
+def test_agent_uses_abstract_context_for_cc_by_publication(
+    requires_credentials: None,
+) -> None:
+    """Agent should cite abstract evidence when the publication is CC BY 4.0.
+
+    Fixture: submission_cc_by_publication.json
+    DOI:     10.1038/s41564-020-00861-0  (Nature Microbiology 2021, CC BY 4.0)
+
+    The full pipeline (nmdc-metadata-suggestor skill) fetches the abstract via
+    doi-ingestion, passes it through doi-copyright-check (verdict=allowed), and
+    includes it as LLM context.  At least one suggestion should cite the abstract
+    as its evidence source.
+    """
+    from nmdc_metadata_suggestor_ai_tool.llm_client import ConversationManager, LLMClient
+    from nmdc_metadata_suggestor_ai_tool.models.llm_output import LLMOutput
+    from nmdc_metadata_suggestor_ai_tool.system_prompt import orchestrator_prompt
+
+    submission = _load("submission_cc_by_publication.json")
+    client = LLMClient(access_provider="gcp")
+    cm = ConversationManager(llm_client=client, system_prompt=orchestrator_prompt)
+
+    result = asyncio.run(cm.agentic(message=str(submission)))
+
+    assert result is not None, "agentic() returned None"
+    structured, session_id = result
+    assert session_id is not None
+
+    output = (
+        structured if isinstance(structured, LLMOutput) else LLMOutput.model_validate(structured)
+    )
+    assert output.metadata_fields, "Expected at least one metadata field suggestion"
+
+    # At least one reason should reference the abstract, confirming context was used.
+    reasons = [f.reason.lower() for f in output.metadata_fields if f.reason]
+    abstract_cited = any("abstract" in r for r in reasons)
+    assert abstract_cited, (
+        "Expected at least one suggestion to cite the abstract as evidence. "
+        f"Got reasons: {reasons}"
+    )
+
+
+@pytest.mark.integration
+@pytest.mark.timeout(INTEGRATION_TIMEOUT)
+def test_agent_does_not_cite_abstract_for_restricted_publication(
+    requires_credentials: None,
+) -> None:
+    """Agent must not cite the abstract when the publication has no CC license.
+
+    Fixture: submission_restricted_publication.json
+    DOI:     10.1126/science.aav2566  (Science 2017, all rights reserved)
+
+    doi-copyright-check returns verdict=not_allowed, so the abstract is excluded
+    from LLM context.  The agent may still suggest fields from the submission's
+    own description, notes, and sample data — but must not cite the abstract.
+    """
+    from nmdc_metadata_suggestor_ai_tool.llm_client import ConversationManager, LLMClient
+    from nmdc_metadata_suggestor_ai_tool.models.llm_output import LLMOutput
+    from nmdc_metadata_suggestor_ai_tool.system_prompt import orchestrator_prompt
+
+    submission = _load("submission_restricted_publication.json")
+    client = LLMClient(access_provider="gcp")
+    cm = ConversationManager(llm_client=client, system_prompt=orchestrator_prompt)
+
+    result = asyncio.run(cm.agentic(message=str(submission)))
+
+    assert result is not None, "agentic() returned None"
+    structured, session_id = result
+    assert session_id is not None
+
+    output = (
+        structured if isinstance(structured, LLMOutput) else LLMOutput.model_validate(structured)
+    )
+
+    # Suggestions may still come from submission description / sample data.
+    # The key constraint: no reason should cite the abstract as evidence.
+    reasons = [f.reason.lower() for f in output.metadata_fields if f.reason]
+    abstract_cited = any("abstract" in r for r in reasons)
+    assert not abstract_cited, (
+        "Agent cited the abstract for a restricted publication — "
+        "copyright check should have excluded it. "
+        f"Got reasons: {reasons}"
+    )

--- a/tests/test_doi_copyright.py
+++ b/tests/test_doi_copyright.py
@@ -4,7 +4,7 @@ Unit tests cover the decision rules in ``.claude/skills/doi-copyright-check/SKIL
 
 * CC BY family → allowed (with attribution condition)
 * CC BY-ND → allowed (verbatim only)
-* CC BY-NC family → not_allowed (non-commercial restriction)
+* CC BY-NC family → allowed (non-commercial use only; restriction noted in condition)
 * CC0 / public domain → allowed (no attribution required)
 * All-rights-reserved / no CC license → not_allowed
 * No license info at all → uncertain
@@ -141,11 +141,11 @@ def test_all_rights_reserved_publication_is_not_allowed(
         # CC BY-ND — allowed (verbatim-only caveat)
         ("https://creativecommons.org/licenses/by-nd/4.0/", "allowed"),
         ("CC BY-ND 3.0", "allowed"),
-        # CC BY-NC family — not_allowed (non-commercial restriction)
-        ("https://creativecommons.org/licenses/by-nc/4.0/", "not_allowed"),
-        ("CC BY-NC 4.0", "not_allowed"),
-        ("https://creativecommons.org/licenses/by-nc-sa/4.0/", "not_allowed"),
-        ("https://creativecommons.org/licenses/by-nc-nd/4.0/", "not_allowed"),
+        # CC BY-NC family — allowed for PNNL internal use (non-commercial restriction in condition)
+        ("https://creativecommons.org/licenses/by-nc/4.0/", "allowed"),
+        ("CC BY-NC 4.0", "allowed"),
+        ("https://creativecommons.org/licenses/by-nc-sa/4.0/", "allowed"),
+        ("https://creativecommons.org/licenses/by-nc-nd/4.0/", "allowed"),
         # CC0 / public domain — allowed
         ("https://creativecommons.org/publicdomain/zero/1.0/", "allowed"),
         ("CC0 1.0", "allowed"),
@@ -186,13 +186,15 @@ def test_all_rights_reserved_string_is_not_allowed() -> None:
 
 
 def test_license_url_by_nc_parsed_correctly() -> None:
-    """CC BY-NC URL is parsed to the correct slug and returns not_allowed."""
+    """CC BY-NC URL is parsed to the correct slug and returns allowed (non-commercial use only)."""
     result = check_doi_copyright(
         doi="10.9999/nc-url",
         license_string="http://creativecommons.org/licenses/by-nc/4.0/",
     )
-    assert result.verdict == "not_allowed"
+    assert result.verdict == "allowed"
     assert result.license_found is not None
+    assert result.condition is not None
+    assert "non-commercial" in result.condition.lower()
 
 
 def test_license_url_by_sa_parsed_correctly() -> None:


### PR DESCRIPTION
Create a Skill that helps the agent avoid using DOIs that are not cleared for AI use. As a side affect of this, it will also create clear documentation around current copywrite and AI policies. 
IMPORTANT - This PR also makes changes to the agentic path:
- adds a permission override for bash commands and tool use. I was noticing that the agent is really held back by not having permissions for this. I think it should be opened up or else we are **not** leveraging agentic processes well. As a result - **we will need** to containerize this when we deploy to nmdc-sever or we are really opening ourselves up to security risks. 
- Updates the **orchestration prompt** to discourage WebSearch and any bash commands that are outside of direct skill usage. 
- Updates the **langfuse tracing** to log each agent message - this will increase logs and observations but I was finding I wanted more info from the logs than I was getting. 