### PR TITLE
Rank supplements by file kind before applying the caps

### DIFF
--- a/.claude/skills/supplement-retrieval/SKILL.md
+++ b/.claude/skills/supplement-retrieval/SKILL.md
@@ -22,6 +22,11 @@ samples and studies. Keep, in priority order:
 Skip (low value for metadata suggestion): figures/images, audio/video, raw
 sequence data (`.fasta`, `.fastq`, `.bam`, …), and nested archives.
 
+This is a ranking, not just a filter: when a record offers more files than the
+caps allow (default `max_files=10`), the budget goes to the tabular files first
+and only the leftovers go to documents — a record with 12 spreadsheets and 3 PDFs
+returns 10 spreadsheets, not whichever 10 the repository happened to list first.
+
 ## Performance first
 
 Supplements are a *nice-to-have*, not a blocker. Make **one** attempt per DOI. If

--- a/.claude/skills/supplement-retrieval/refs/programmatic.md
+++ b/.claude/skills/supplement-retrieval/refs/programmatic.md
@@ -27,8 +27,14 @@ from nmdc_metadata_suggestor_ai_tool.file_kinds import (
     DEFAULT_USEFUL_KINDS,  # {TABULAR, DOCUMENT}
     EXTENSION_KINDS,  # extension -> SupplementKind, the full mapping
     TEXT_LIKE_EXTENSIONS,  # extensions inlined as text rather than saved
+    KIND_PRIORITY,  # kinds in the order they win a contested budget
+    kind_rank,  # SupplementKind -> sort rank (lower = more valuable)
 )
 ```
+
+`KIND_PRIORITY` orders every kind most-valuable-first — `tabular`, `document`,
+`archive`, `other`, `sequence`, `image`, `media` — and is what decides *which*
+files survive a cap, not just which kinds are eligible.
 
 `DEFAULT_USEFUL_KINDS` and `classify_file` (aliased there as
 `classify_supplement`) are also re-exported from the supplements package, so
@@ -74,7 +80,10 @@ retrieve_supplements(
 hosted supplements (Europe PMC) **plus** any
 data-repository datasets found via relation metadata (`follow_related`) or mined
 from `text`. Files from all contributing sources are merged and trimmed to
-`max_files` / `max_total_bytes`; `SupplementFile.source` records each file's
+`max_files` / `max_total_bytes` **in `KIND_PRIORITY` order**, so when more files
+qualify than the caps allow, spreadsheets and delimited files are kept ahead of
+documents, and documents ahead of figures — regardless of listing or source order.
+Within one kind the original order is preserved. `SupplementFile.source` records each file's
 origin and `result.source` joins the contributors with `+`. When nothing is kept,
 the first source that *found* candidates is returned so its `skipped`/`error`
 detail is preserved. Pass an explicit `sources=[...]` to bypass routing.
@@ -94,7 +103,9 @@ skipped by reported size *before* being read, and no archive is buffered beyond
 `max_archive_bytes`. Across a publication's sources the caps act as one **shared
 budget**: hosted supplements are fetched first and each linked dataset only pulls
 what remains of `max_files` / `max_total_bytes`, so the total downloaded never
-exceeds the global caps.
+exceeds the global caps. Kind priority ranks what has been fetched; it cannot
+reach across the fetch order, so a source that spends the whole `max_files`
+budget leaves later sources' files undownloaded and therefore unranked.
 
 ## Return: `SupplementRetrievalResult`
 

--- a/src/nmdc_metadata_suggestor_ai_tool/file_kinds.py
+++ b/src/nmdc_metadata_suggestor_ai_tool/file_kinds.py
@@ -74,6 +74,30 @@ DEFAULT_USEFUL_KINDS: frozenset[SupplementKind] = frozenset(
     {SupplementKind.TABULAR, SupplementKind.DOCUMENT}
 )
 
+# Order in which kinds win a contested file budget, most valuable first. Used to
+# rank candidates before a cap is applied, so a listing of 40 figures followed by
+# one spreadsheet still yields the spreadsheet. Covers every ``SupplementKind``.
+KIND_PRIORITY: tuple[SupplementKind, ...] = (
+    SupplementKind.TABULAR,  # spreadsheets/delimited files: the per-sample data itself
+    SupplementKind.DOCUMENT,  # supplementary methods and site descriptions
+    SupplementKind.ARCHIVE,  # may bundle tables, so worth more than a figure
+    SupplementKind.OTHER,  # unrecognized; sometimes delimited data under an odd suffix
+    SupplementKind.SEQUENCE,  # data, but too bulky to help characterize samples
+    SupplementKind.IMAGE,  # figures/gels: no machine-readable values
+    SupplementKind.MEDIA,
+)
+
+KIND_RANKS: dict[SupplementKind, int] = {kind: rank for rank, kind in enumerate(KIND_PRIORITY)}
+
+
+def kind_rank(kind: SupplementKind) -> int:
+    """Return the sort rank of *kind* -- lower is more valuable.
+
+    Pair with a *stable* sort so files of equal rank keep their listing order
+    (which usually runs Table S1, S2, ... within a source).
+    """
+    return KIND_RANKS.get(kind, len(KIND_PRIORITY))
+
 
 def file_extension(filename: str) -> str:
     """Return the lowercase extension of *filename* without the dot (``""`` if none)."""

--- a/src/nmdc_metadata_suggestor_ai_tool/publication_ingestion/supplements/__init__.py
+++ b/src/nmdc_metadata_suggestor_ai_tool/publication_ingestion/supplements/__init__.py
@@ -6,7 +6,8 @@ package therefore favors *performance over completeness*:
 
 * Only high-value file kinds (tabular data and documents; see
   :class:`~nmdc_metadata_suggestor_ai_tool.models.supplement.SupplementKind`)
-  are kept by default.
+  are kept by default, and when more candidates pass the filter than the caps
+  allow, they are kept in ``KIND_PRIORITY`` order -- data-like files first.
 * Downloads are bounded by size/count caps and are never retried beyond
   ``request_with_retry``'s transient-error handling. If supplements are hard to
   obtain, we give up quickly rather than hammering the source.
@@ -25,7 +26,11 @@ For publisher-hosted supplements behind Cloudflare/JS challenges, prefer the
 agentic ``web_fetch`` path documented in the ``supplement-retrieval`` skill.
 """
 
-from nmdc_metadata_suggestor_ai_tool.file_kinds import DEFAULT_USEFUL_KINDS
+from nmdc_metadata_suggestor_ai_tool.file_kinds import (
+    DEFAULT_USEFUL_KINDS,
+    KIND_PRIORITY,
+    kind_rank,
+)
 from nmdc_metadata_suggestor_ai_tool.publication_ingestion.supplements.dryad import (
     is_dryad_doi,
     retrieve_supplements_from_dryad,
@@ -56,6 +61,7 @@ from nmdc_metadata_suggestor_ai_tool.publication_ingestion.supplements.zenodo im
 
 __all__ = [
     "DEFAULT_USEFUL_KINDS",
+    "KIND_PRIORITY",
     "SupplementCaps",
     "classify_supplement",
     "extract_accessions_from_text",
@@ -63,6 +69,7 @@ __all__ = [
     "find_related_data_dois",
     "find_supplement_source_europepmc",
     "is_dryad_doi",
+    "kind_rank",
     "parse_supplement_captions",
     "retrieve_supplements",
     "retrieve_supplements_from_dryad",

--- a/src/nmdc_metadata_suggestor_ai_tool/publication_ingestion/supplements/retrieve.py
+++ b/src/nmdc_metadata_suggestor_ai_tool/publication_ingestion/supplements/retrieve.py
@@ -18,7 +18,7 @@ from nmdc_metadata_suggestor_ai_tool.constants import (
     SUPPLEMENT_MAX_TOTAL_BYTES,
 )
 from nmdc_metadata_suggestor_ai_tool.doi_ingestion.doi_utils import normalize_doi
-from nmdc_metadata_suggestor_ai_tool.file_kinds import DEFAULT_USEFUL_KINDS
+from nmdc_metadata_suggestor_ai_tool.file_kinds import DEFAULT_USEFUL_KINDS, kind_rank
 from nmdc_metadata_suggestor_ai_tool.models.supplement import (
     SupplementFile,
     SupplementKind,
@@ -82,6 +82,12 @@ def retrieve_supplements(
     remains of ``max_files`` / ``max_total_bytes``, so the total downloaded never
     exceeds the global caps. Each ``SupplementFile.source`` records its origin.
     Pass ``sources`` to run an explicit source list instead of the default routing.
+
+    Within each source, and again across the merged union, files compete for the
+    caps in ``KIND_PRIORITY`` order, so a spreadsheet is kept ahead of a document
+    or figure. Priority cannot reach across the fetch order, though: a source that
+    spends the whole ``max_files`` budget leaves nothing for later sources, whose
+    files are never downloaded and so never enter the ranking.
 
     Returns:
         A merged :class:`SupplementRetrievalResult`. When nothing is kept, the
@@ -194,6 +200,11 @@ def merge_results(
 ) -> SupplementRetrievalResult:
     """Merge per-source results into one, trimming the union to global caps.
 
+    The union is ranked by :func:`kind_rank` before trimming, so the global caps
+    fall on the least data-like files: a spreadsheet from the last source outranks
+    a figure from the first. The sort is stable, so files of equal kind keep the
+    source order they arrived in (hosted supplements ahead of linked datasets).
+
     Files dropped by the global caps have their temp file removed so nothing
     leaks. When *save_dir* is set the sources wrote into a caller-managed
     directory instead, so dropped paths are left alone -- they are the caller's
@@ -203,29 +214,32 @@ def merge_results(
     for res in results:
         attempts.extend(res.attempts)
 
+    candidates = sorted(
+        (file for res in results for file in res.files),
+        key=lambda file: kind_rank(file.kind),
+    )
     kept: list[SupplementFile] = []
     seen: set[tuple[str | None, str]] = set()
     total_bytes = 0
-    for res in results:
-        for file in res.files:
-            # Key on the full filename, not the basename: one source can legitimately
-            # carry two distinct files that share a basename (e.g. ``a/Table_S1.xlsx``
-            # and ``b/Table_S1.xlsx``), and collapsing them would lose one.
-            key = (file.source, file.filename)
-            keep = (
-                key not in seen
-                and len(kept) < max_files
-                and total_bytes + (file.size_bytes or 0) <= max_total_bytes
-            )
-            if keep:
-                seen.add(key)
-                total_bytes += file.size_bytes or 0
-                kept.append(file)
-            elif file.saved_path and save_dir is None and is_removable_temp_file(file.saved_path):
-                # This file was already materialized to a temp file by its source
-                # but is being dropped from the merged result (cap/dedup). Delete
-                # it so it doesn't leak -- the caller can only clean files it sees.
-                remove_temp_file(file.saved_path)
+    for file in candidates:
+        # Key on the full filename, not the basename: one source can legitimately
+        # carry two distinct files that share a basename (e.g. ``a/Table_S1.xlsx``
+        # and ``b/Table_S1.xlsx``), and collapsing them would lose one.
+        key = (file.source, file.filename)
+        keep = (
+            key not in seen
+            and len(kept) < max_files
+            and total_bytes + (file.size_bytes or 0) <= max_total_bytes
+        )
+        if keep:
+            seen.add(key)
+            total_bytes += file.size_bytes or 0
+            kept.append(file)
+        elif file.saved_path and save_dir is None and is_removable_temp_file(file.saved_path):
+            # This file was already materialized to a temp file by its source
+            # but is being dropped from the merged result (cap/dedup). Delete
+            # it so it doesn't leak -- the caller can only clean files it sees.
+            remove_temp_file(file.saved_path)
 
     merged = SupplementRetrievalResult(
         doi=doi,

--- a/src/nmdc_metadata_suggestor_ai_tool/publication_ingestion/supplements/shared.py
+++ b/src/nmdc_metadata_suggestor_ai_tool/publication_ingestion/supplements/shared.py
@@ -25,6 +25,7 @@ from nmdc_metadata_suggestor_ai_tool.file_kinds import (
     TEXT_LIKE_EXTENSIONS,
     classify_file,
     file_extension,
+    kind_rank,
 )
 from nmdc_metadata_suggestor_ai_tool.models.supplement import (
     SupplementFile,
@@ -249,10 +250,19 @@ def select_members(
     size *before* reading, so oversized files are never downloaded/extracted, and
     re-checked against the actual byte count afterwards -- sources that report a
     zero/unknown ``size`` would otherwise slip past the budget.
+
+    Members are considered in :func:`kind_rank` order (data-like files first) so
+    that when the listing holds more candidates than ``max_files``, the budget
+    goes to spreadsheets and delimited files rather than to whatever the source
+    happened to list first. The sort is stable, so within one kind the source's
+    own order survives.
     """
     kept: list[SupplementFile] = []
     skipped: list[SupplementFile] = []
     total_kept_bytes = 0
+    # Ranking needs the whole listing up front; ``Member.read`` stays lazy, so
+    # this materializes names and sizes only, never file content.
+    members = sorted(members, key=lambda member: kind_rank(classify_supplement(member.name)))
 
     def skip(name: str, kind: SupplementKind, size: int, reason: str) -> None:
         skipped.append(

--- a/tests/test_file_kinds.py
+++ b/tests/test_file_kinds.py
@@ -3,9 +3,11 @@
 from nmdc_metadata_suggestor_ai_tool.file_kinds import (
     DEFAULT_USEFUL_KINDS,
     EXTENSION_KINDS,
+    KIND_PRIORITY,
     TEXT_LIKE_EXTENSIONS,
     classify_file,
     file_extension,
+    kind_rank,
 )
 from nmdc_metadata_suggestor_ai_tool.models.supplement import SupplementKind
 
@@ -32,6 +34,22 @@ def test_taxonomy_constants_are_consistent() -> None:
     for ext in TEXT_LIKE_EXTENSIONS:
         assert ext in EXTENSION_KINDS
     assert DEFAULT_USEFUL_KINDS == frozenset({SupplementKind.TABULAR, SupplementKind.DOCUMENT})
+
+
+def test_kind_priority_ranks_data_like_first() -> None:
+    # A cap that can only hold some files must spend it on the data-like ones.
+    assert kind_rank(SupplementKind.TABULAR) < kind_rank(SupplementKind.DOCUMENT)
+    for lesser in (SupplementKind.IMAGE, SupplementKind.MEDIA, SupplementKind.SEQUENCE):
+        assert kind_rank(SupplementKind.TABULAR) < kind_rank(lesser)
+        assert kind_rank(SupplementKind.DOCUMENT) < kind_rank(lesser)
+
+
+def test_kind_priority_covers_every_kind() -> None:
+    # A kind missing from KIND_PRIORITY would silently sort last; adding a new
+    # SupplementKind must mean placing it deliberately.
+    assert set(KIND_PRIORITY) == set(SupplementKind)
+    assert len(KIND_PRIORITY) == len(set(KIND_PRIORITY))
+    assert sorted(SupplementKind, key=kind_rank) == list(KIND_PRIORITY)
 
 
 def test_classify_supplement_alias_still_works() -> None:

--- a/tests/test_supplement_retrieval.py
+++ b/tests/test_supplement_retrieval.py
@@ -150,6 +150,50 @@ def test_select_members_rejects_member_larger_than_reported() -> None:
     assert "byte cap" in (skipped[0].skipped_reason or "")
 
 
+def test_select_members_spends_max_files_on_data_like_kinds() -> None:
+    # The source lists documents first, but a cap this tight must go to the
+    # spreadsheets -- they carry the per-sample values we are after.
+    members = [
+        Member(name="methods.txt", size=4, read=lambda: b"aaaa"),
+        Member(name="notes.txt", size=4, read=lambda: b"bbbb"),
+        Member(name="Table_S1.csv", size=4, read=lambda: b"a,b\n"),
+        Member(name="Table_S2.csv", size=4, read=lambda: b"c,d\n"),
+    ]
+    kept, skipped = select_members(
+        members,
+        kept_kinds=frozenset({SupplementKind.TABULAR, SupplementKind.DOCUMENT}),
+        max_files=2,
+        max_file_bytes=100,
+        max_total_bytes=1000,
+        max_text_chars=1000,
+        save_dir=None,
+        captions=None,
+    )
+    # Ranking is by kind first, then the source's own order within a kind.
+    assert [f.filename for f in kept] == ["Table_S1.csv", "Table_S2.csv"]
+    assert {f.filename for f in skipped} == {"methods.txt", "notes.txt"}
+    assert all("max_files" in (f.skipped_reason or "") for f in skipped)
+
+
+def test_select_members_spends_max_total_bytes_on_data_like_kinds() -> None:
+    # The byte cap is ranked the same way: a big document must not crowd out a
+    # table that was listed after it.
+    kept, _skipped = select_members(
+        [
+            Member(name="methods.pdf", size=80, read=lambda: b"%PDF" + b"x" * 76),
+            Member(name="Table_S1.csv", size=40, read=lambda: b"a,b\n" * 10),
+        ],
+        kept_kinds=frozenset({SupplementKind.TABULAR, SupplementKind.DOCUMENT}),
+        max_files=10,
+        max_file_bytes=100,
+        max_total_bytes=100,
+        max_text_chars=1000,
+        save_dir=None,
+        captions=None,
+    )
+    assert [f.filename for f in kept] == ["Table_S1.csv"]
+
+
 def test_select_members_keeps_colliding_basenames_apart(tmp_path) -> None:
     # Two members share a basename (one nested in an archive). With save_dir set
     # they must not write to the same path, or the first file's bytes are lost
@@ -366,6 +410,28 @@ def test_europepmc_respects_max_files() -> None:
     result = retrieve_supplements_from_europepmc(DOI, max_files=2)
     assert len(result.files) == 2
     assert any("max_files" in (f.skipped_reason or "") for f in result.skipped)
+
+
+@responses.activate
+def test_europepmc_max_files_goes_to_tabular_over_documents() -> None:
+    # The archive lists its documents first; the cap must still land on the
+    # spreadsheets, which is where the per-sample metadata lives.
+    _register_search()
+    archive = _make_zip(
+        {
+            "methods.pdf": b"%PDF-1.4 methods",
+            "protocol.pdf": b"%PDF-1.4 protocol",
+            "Table_S1.csv": b"sample_id,depth\nA,10\n",
+            "Table_S2.csv": b"sample_id,ph\nA,7\n",
+        }
+    )
+    responses.add(responses.GET, SUPPL_URL, body=archive, status=200)
+    responses.add(responses.GET, FULLTEXT_URL, body=b"<article/>", status=200)
+
+    result = retrieve_supplements_from_europepmc(DOI, max_files=2)
+
+    assert [f.filename for f in result.files] == ["Table_S1.csv", "Table_S2.csv"]
+    assert {f.filename for f in result.skipped} == {"methods.pdf", "protocol.pdf"}
 
 
 @responses.activate
@@ -851,6 +917,37 @@ def test_merge_results_deletes_trimmed_temp_files(tmp_path) -> None:
     assert [f.filename for f in merged.files] == ["kept.pdf"]
     assert kept_path.exists()  # kept file's temp path untouched
     assert not dropped_path.exists()  # trimmed file's temp path deleted (no leak)
+
+
+def test_merge_results_prefers_data_like_files_across_sources() -> None:
+    # The global cap is spent on kind, not on which source happened to run first:
+    # a linked dataset's spreadsheet outranks a hosted document.
+    from nmdc_metadata_suggestor_ai_tool.models.supplement import (
+        SupplementFile,
+        SupplementRetrievalResult,
+    )
+
+    def _file(name: str, kind: SupplementKind, source: str) -> SupplementFile:
+        return SupplementFile(filename=name, kind=kind, source=source, size_bytes=10, text="x")
+
+    hosted = SupplementRetrievalResult(
+        doi="x",
+        source="europepmc",
+        files=[
+            _file("methods.pdf", SupplementKind.DOCUMENT, "europepmc"),
+            _file("Table_S1.csv", SupplementKind.TABULAR, "europepmc"),
+        ],
+    )
+    linked = SupplementRetrievalResult(
+        doi="x",
+        source="zenodo",
+        files=[_file("samples.xlsx", SupplementKind.TABULAR, "zenodo")],
+    )
+
+    merged = merge_results("x", [hosted, linked], [], max_files=2, max_total_bytes=1_000_000)
+
+    assert [f.filename for f in merged.files] == ["Table_S1.csv", "samples.xlsx"]
+    assert merged.source == "europepmc+zenodo"
 
 
 def test_merge_results_keeps_same_basename_from_one_source() -> None:


### PR DESCRIPTION
Fixes #142 

Supplementarty files retrieved using the scripts added by #132 competed for max_files/max_total_bytes by listing position, so a record whose repository listed figures and PDFs first could spend the whole budget before reaching a single spreadsheet, though these are the files that may actually carry per-sample metadata.

Add `KIND_PRIORITY` to file_kinds: a total order over every SupplementKind, data-like first (tabular > document > archive > other > sequence > image > media), with kind_rank() as its sort key. A test asserts the tuple
covers the whole enum, so a new kind must be placed deliberately rather than sorting last by accident.

Apply it in the two places a cap is enforced:

* select_members stable-sorts the listing before spending the budget, so every source inherits the ranking. Member.read stays lazy, so this reorders names and sizes without triggering a download.
* merge_results ranks the cross-source union the same way, letting a linked dataset's spreadsheet outrank a hosted figure.

Both sorts are stable, so within one kind the previous order survives (source listing order, and hosted supplements ahead of linked datasets).

Priority ranks what has been fetched; it cannot reach across the fetch order, since a source that exhausts max_files leaves later sources' files undownloaded. Documented on retrieve_supplements and in the skill reference rather than fixed, as over-fetching to discard would defeat the purpose of doing a rapid check for available supplementary context.