### PR TITLE
Fix the setup and Quickstart docs

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -30,11 +30,9 @@ VERTEX_PROJECT_ID=your_gcp_project_id
 GCP_REGION=us-east5
 
 # Claude Agent SDK configuration, used only by ConversationManager.agentic().
-# That path runs a Claude model through the Claude Code CLI, which reads these to
+# That path runs a Claude model through the Claude Code CLI, which reads this to
 # route to Vertex. Unused by the Gemini path.
 CLAUDE_CODE_USE_VERTEX=1
-ANTHROPIC_VERTEX_PROJECT_ID=your_gcp_project_id
-CLOUD_ML_REGION=us-east5
 
 # DOI / Publication APIs
 # Contact email used in User-Agent headers for Crossref polite pool and OpenAlex.

--- a/.env.example
+++ b/.env.example
@@ -29,6 +29,13 @@ VERTEX_PROJECT_ID=your_gcp_project_id
 # Default Vertex region (the code default is us-east5 if unset)
 GCP_REGION=us-east5
 
+# Claude Agent SDK configuration, used only by ConversationManager.agentic().
+# That path runs a Claude model through the Claude Code CLI, which reads these to
+# route to Vertex. Unused by the Gemini path.
+CLAUDE_CODE_USE_VERTEX=1
+ANTHROPIC_VERTEX_PROJECT_ID=your_gcp_project_id
+CLOUD_ML_REGION=us-east5
+
 # DOI / Publication APIs
 # Contact email used in User-Agent headers for Crossref polite pool and OpenAlex.
 # Crossref: https://github.com/CrossRef/rest-api-doc#good-manners--more-reliable-service

--- a/README.md
+++ b/README.md
@@ -67,25 +67,35 @@ default).
    ```
 
    ```python
+   import json
+
    from nmdc_metadata_suggestor_ai_tool.llm_client import LLMClient
    from nmdc_metadata_suggestor_ai_tool.recommendation_pipeline import run_recommendation_pipeline
 
-   submission_object = {
-       # NMDC submission JSON payload
-   }
+   # Any NMDC submission JSON payload. This example fixture ships with the repo:
+   # a soil study with a data DOI, so the run also exercises DOI abstract ingestion.
+   with open("tests/fixtures/test_submission.json") as f:
+       submission_object = json.load(f)
 
    client = LLMClient(access_provider="gcp")
    result = run_recommendation_pipeline(submission_object, client)
-   print(result.model_dump())
+   print(result.model_dump_json(indent=2))
    ```
+
+   Each suggestion names an NMDC field the submitter should fill in and a `reason` citing
+   the submission text that supports it. `value` is filled in only when the submission
+   contains that value literally; when the value is inferred, the inference goes in the
+   `reason` and `value` stays `""`. An empty `value` is expected output, not a failure.
+   (The env triad path is the exception — it always returns a `label [CURIE]` value.)
 
 Advanced: direct `ConversationManager` usage (optional)
 
 ```python
 from nmdc_metadata_suggestor_ai_tool.llm_client import LLMClient, ConversationManager
+from nmdc_metadata_suggestor_ai_tool.system_prompt import system_prompt
 
 client = LLMClient(access_provider="gcp")
-conversation = ConversationManager(llm_client=client)
+conversation = ConversationManager(llm_client=client, system_prompt=system_prompt)
 # Add plain text context (pdf_files may be a list of local PDF paths)
 conversation.add_message(text="Please summarize the submission.", pdf_files=None)
 # Add any schema context to guide the model

--- a/README.md
+++ b/README.md
@@ -24,6 +24,7 @@ Environment variables used by `LLMClient` and `ConversationManager`:
 - `GOOGLE_APPLICATION_CREDENTIALS`: Path to a GCP service account JSON file (for Vertex AI).
 - `VERTEX_PROJECT_ID`: (Optional) GCP project id for Vertex. If not provided, the SDK will attempt to infer it from credentials.
 - `GCP_REGION`: (Optional) Vertex region override for Gemini calls (falls back to `GCP_REGION`, then `us-east5`).
+- `CLAUDE_CODE_USE_VERTEX`, `ANTHROPIC_VERTEX_PROJECT_ID`, `CLOUD_ML_REGION`: Required only by the agentic path (`ConversationManager.agentic()`), which runs a Claude model through the Claude Code CLI. Without them the CLI does not route to Vertex, and the run fails reporting that the model may not exist or is not accessible.
 - `CBORG_KEY`: API key for CBORG (when using `access_provider=cborg`).
 - `CBORG_BASE_URL`: Base URL for the CBORG API.
 

--- a/README.md
+++ b/README.md
@@ -24,7 +24,7 @@ Environment variables used by `LLMClient` and `ConversationManager`:
 - `GOOGLE_APPLICATION_CREDENTIALS`: Path to a GCP service account JSON file (for Vertex AI).
 - `VERTEX_PROJECT_ID`: (Optional) GCP project id for Vertex. If not provided, the SDK will attempt to infer it from credentials.
 - `GCP_REGION`: (Optional) Vertex region override for Gemini calls (falls back to `GCP_REGION`, then `us-east5`).
-- `CLAUDE_CODE_USE_VERTEX`, `ANTHROPIC_VERTEX_PROJECT_ID`, `CLOUD_ML_REGION`: Required only by the agentic path (`ConversationManager.agentic()`), which runs a Claude model through the Claude Code CLI. Without them the CLI does not route to Vertex, and the run fails reporting that the model may not exist or is not accessible.
+- `CLAUDE_CODE_USE_VERTEX` (Required by ConversationManager.agentic()) : Forces `claude_agent_sdk` to use vertex AI for credentials. Required for our use as we use GCP for agentic auth. 
 - `CBORG_KEY`: API key for CBORG (when using `access_provider=cborg`).
 - `CBORG_BASE_URL`: Base URL for the CBORG API.
 


### PR DESCRIPTION
Documentation fixes from getting set up with this repo for development.

- Document `CLAUDE_CODE_USE_VERTEX`, which the agentic path needs to route to Vertex. The other two Vertex variables I'd added are optional after all — the CLI defaults the region to `us-east5` and reads the project from the service account credentials — so they're out.
- Make the Quickstart runnable: load a fixture that ships with the repo instead of an empty placeholder.
- Explain the output: an empty `value` is expected, since the pipeline suggests which fields to fill in and why, not the values themselves.
- Fix the `ConversationManager` example, which omitted the required `system_prompt` argument.

Closes #103