### PR TITLE
Declare every target in .PHONY, and check it stays that way

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -43,16 +43,6 @@ cp .env.example .env
 # Edit .env and add your API keys
 ```
 
-Using Docker:
-```bash
-# Start development environment
-docker-compose up
-
-# Or for interactive development
-docker-compose up -d
-docker-compose exec app bash
-```
-
 ### Code Quality
 
 Before submitting a pull request, ensure your code passes all quality checks:

--- a/Makefile
+++ b/Makefile
@@ -1,10 +1,15 @@
-# Targets that really do build a file or directory named after themselves.
-# These must NOT be listed in .PHONY; every other target must be. Empty today,
-# because nothing here builds an artifact of its own name. See
-# docs/makefile-phony.md.
+# Every target below is listed in .PHONY, because none of them creates a file
+# named after itself. That is the whole rule: declare a target phony unless
+# running it writes a file or directory of that exact name.
+#
+# FILE_TARGETS is the escape hatch for the exception. If a target ever does
+# build a file named after itself, list it here INSTEAD of in .PHONY, and make
+# will use its timestamp to skip rebuilds. Nothing qualifies today, so it is
+# empty. `make check-phony` fails if a target is in both lists or neither.
+# Background: docs/makefile-phony.md.
 FILE_TARGETS =
 
-.PHONY: help all-install prod-install dev-install test test-integration lint check-phony format security check-deps clean docker-build docker-dev-build docker-run docker-dev docker-dev-down docker-shell run validate-doi classify-doi classify-fixture get-abstract get-abstracts
+.PHONY: help all-install prod-install dev-install test test-integration lint check-phony format security check-deps clean run validate-doi classify-doi classify-fixture get-abstract get-abstracts
 
 help: ## Show this help message
 	@echo "Usage: make [target]"
@@ -59,24 +64,6 @@ clean: ## Clean up generated files
 	rm -rf *.egg-info
 	find . -type d -name __pycache__ -exec rm -rf {} +
 	find . -type f -name "*.pyc" -delete
-
-docker-build: ## Build production Docker image
-	docker build -t nmdc-suggestor:latest .
-
-docker-dev-build: ## Build development Docker image
-	docker build -f Dockerfile.dev -t nmdc-suggestor:dev .
-
-docker-run: ## Run production Docker container
-	docker run --env-file .env nmdc-suggestor:latest
-
-docker-dev: ## Start development environment with Docker Compose
-	docker-compose up
-
-docker-dev-down: ## Stop development environment
-	docker-compose down
-
-docker-shell: ## Open shell in development container
-	docker-compose exec app bash
 
 run: ## Run the application locally
 	uv run nmdc-suggestor

--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-.PHONY: help all-install prod-install dev-install test test-integration lint format security check-deps clean docker-build docker-dev-build docker-run docker-dev docker-dev-down docker-shell run validate-doi classify-doi classify-fixture get-abstract get-abstracts
+.PHONY: help all-install prod-install dev-install test test-integration lint check-phony format security check-deps clean docker-build docker-dev-build docker-run docker-dev docker-dev-down docker-shell run validate-doi classify-doi classify-fixture get-abstract get-abstracts
 
 help: ## Show this help message
 	@echo "Usage: make [target]"
@@ -23,7 +23,11 @@ test-integration: ## Run integration tests against real APIs
 
 lint: ## Run linters
 	uv run ruff check
-	uv run mypy src 
+	uv run mypy src
+	$(MAKE) check-phony
+
+check-phony: ## Verify .PHONY lists exactly the targets the Makefile defines
+	uv run python scripts/check_phony.py
 
 format: ## This is a two part command that both checks, then auto-fixes formatting issues where it can.
 	uv run ruff format

--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-.PHONY: help dev-install test test-integration lint lint-fix format security check-deps clean docker-build docker-run docker-dev validate-doi classify-doi classify-fixture get-abstract get-abstracts
+.PHONY: help all-install prod-install dev-install test test-integration lint format security check-deps clean docker-build docker-dev-build docker-run docker-dev docker-dev-down docker-shell run validate-doi classify-doi classify-fixture get-abstract get-abstracts
 
 help: ## Show this help message
 	@echo "Usage: make [target]"

--- a/Makefile
+++ b/Makefile
@@ -1,3 +1,9 @@
+# Targets that really do build a file or directory named after themselves.
+# These must NOT be listed in .PHONY; every other target must be. Empty today,
+# because nothing here builds an artifact of its own name. See
+# docs/makefile-phony.md.
+FILE_TARGETS =
+
 .PHONY: help all-install prod-install dev-install test test-integration lint check-phony format security check-deps clean docker-build docker-dev-build docker-run docker-dev docker-dev-down docker-shell run validate-doi classify-doi classify-fixture get-abstract get-abstracts
 
 help: ## Show this help message

--- a/docs/makefile-phony.md
+++ b/docs/makefile-phony.md
@@ -29,8 +29,9 @@ Every target in this Makefile is phony today. None of them writes a file named a
 - a target defined twice
 
 The check exists because the line drifted once already. It listed 17 names against 23 targets,
-so `all-install`, `prod-install`, `docker-dev-build`, `docker-dev-down`, `docker-shell` and `run`
-were all skippable, and it listed `lint-fix`, which was never a target.
+so `all-install`, `prod-install`, `run` and four `docker-*` targets were all skippable, and it
+listed `lint-fix`, which was never a target. The `docker-*` targets have since been removed:
+they called files that were deleted in July.
 
 ## Why not use checkmake
 

--- a/docs/makefile-phony.md
+++ b/docs/makefile-phony.md
@@ -1,0 +1,55 @@
+# Keeping `.PHONY` correct
+
+## The rule
+
+A target is phony when running it produces no file named after the target. Every phony target
+belongs in `.PHONY`, and no target that does build a file of its own name belongs there.
+
+That is GNU make's own definition. `.PHONY` tells make to stop consulting the filesystem for
+that name. Two things go wrong when the line drifts:
+
+- **A phony target left out.** If a file or directory of that name ever appears, make reports
+  `make: 'run' is up to date.` and silently skips the recipe.
+- **A real file target wrongly declared phony.** Make stops checking its timestamp, so it
+  rebuilds every time and other targets can no longer depend on it meaningfully.
+
+Every target in this Makefile is phony today. None of them writes a file named after itself.
+
+## Why this is checked automatically
+
+`make lint` runs `make check-phony`, which runs `scripts/check_phony.py`. It fails on:
+
+- a target missing from `.PHONY`
+- a `.PHONY` entry that is not a target
+- a target name that exists as a path in the repo, which suggests it should not be phony
+- a target defined twice
+
+The check exists because the line drifted once already. It listed 17 names against 23 targets,
+so `all-install`, `prod-install`, `docker-dev-build`, `docker-dev-down`, `docker-shell` and `run`
+were all skippable, and it listed `lint-fix`, which was never a target.
+
+## Why not use checkmake
+
+[checkmake](https://github.com/checkmake/checkmake) is the obvious off-the-shelf Makefile linter
+and it ships a rule called `phonydeclared`. It does not check the rule above. Read from its
+source at `rules/phonydeclared/phonydeclared.go`, the condition is:
+
+```go
+if len(rule.Body) == 0 && !ok {
+    // violation: Target %q should be declared PHONY.
+}
+```
+
+It only fires on targets with **no recipe body**. Every target in this Makefile has a body, so
+checkmake reports zero `phonydeclared` violations against the exact file that was broken. Its
+other phony rule, `minphony`, checks only that a configured list (default `all,clean,test`) is
+present, and says nothing about the rest of the file.
+
+So a green `checkmake` run is not evidence that `.PHONY` is complete. That is why this repo uses
+a local check instead of adding a dependency.
+
+## Adding a target
+
+Add it to `.PHONY` in the same place. `make check-phony` fails if you forget. If the new target
+genuinely builds a file named after itself, leave it out of `.PHONY` and the check will tell you
+so once that file exists.

--- a/docs/makefile-phony.md
+++ b/docs/makefile-phony.md
@@ -21,7 +21,8 @@ Every target in this Makefile is phony today. None of them writes a file named a
 
 - a target missing from `.PHONY`
 - a `.PHONY` entry that is not a target
-- a target name that exists as a path in the repo, which suggests it should not be phony
+- a target name that also exists as a path in the working tree, tracked or untracked, since that
+  is exactly when a non-phony target gets silently skipped
 - a target defined twice
 
 The check exists because the line drifted once already. It listed 17 names against 23 targets,
@@ -51,5 +52,9 @@ a local check instead of adding a dependency.
 ## Adding a target
 
 Add it to `.PHONY` in the same place. `make check-phony` fails if you forget. If the new target
-genuinely builds a file named after itself, leave it out of `.PHONY` and the check will tell you
-so once that file exists.
+genuinely builds a file named after itself, rename the target after the path it builds and leave
+it out of `.PHONY`.
+
+The path check matches untracked files too. That is deliberate: make skips a non-phony target just
+as readily for a stray local directory as for a committed one. If `make lint` fails on this
+locally and the path is junk, delete the path.

--- a/docs/makefile-phony.md
+++ b/docs/makefile-phony.md
@@ -13,14 +13,17 @@ that name. Two things go wrong when the line drifts:
 - **A real file target wrongly declared phony.** Make stops checking its timestamp, so it
   rebuilds every time and other targets can no longer depend on it meaningfully.
 
-Every target in this Makefile is phony today. None of them writes a file named after itself.
+Every target in this Makefile is phony today. None of them writes a file named after itself, so
+`FILE_TARGETS` at the top of the Makefile is empty.
 
 ## Why this is checked automatically
 
 `make lint` runs `make check-phony`, which runs `scripts/check_phony.py`. It fails on:
 
-- a target missing from `.PHONY`
+- a target that is in neither `.PHONY` nor `FILE_TARGETS`
 - a `.PHONY` entry that is not a target
+- a target listed in both `.PHONY` and `FILE_TARGETS`, which contradicts itself
+- a `FILE_TARGETS` entry that is not a target
 - a target name that also exists as a path in the working tree, tracked or untracked, since that
   is exactly when a non-phony target gets silently skipped
 - a target defined twice
@@ -51,9 +54,12 @@ a local check instead of adding a dependency.
 
 ## Adding a target
 
-Add it to `.PHONY` in the same place. `make check-phony` fails if you forget. If the new target
-genuinely builds a file named after itself, rename the target after the path it builds and leave
-it out of `.PHONY`.
+Add it to `.PHONY`. `make check-phony` fails if you forget.
+
+If the new target genuinely builds a file or directory named after itself, add it to
+`FILE_TARGETS` instead and keep it out of `.PHONY`. That is the case make's dependency tracking is
+for, and declaring it there also exempts it from the path check below, since the path existing is
+the expected outcome rather than a problem. Listing a target in both is an error.
 
 The path check matches untracked files too. That is deliberate: make skips a non-phony target just
 as readily for a stray local directory as for a committed one. If `make lint` fails on this

--- a/scripts/check_phony.py
+++ b/scripts/check_phony.py
@@ -1,8 +1,10 @@
 """Check that the Makefile's .PHONY line matches the targets it defines.
 
 A target is phony when running it produces no file named after the target.
-Every target in this Makefile is phony, so .PHONY should list all of them
-and nothing else.
+Every phony target must be in .PHONY. A target that genuinely does build a
+file of its own name must instead be listed in the Makefile's FILE_TARGETS
+variable, and kept out of .PHONY. Every target must be in exactly one of the
+two.
 
 checkmake's rule of the same name does not check this: its `phonydeclared`
 only fires on targets with an empty recipe body, so it passes a Makefile
@@ -24,6 +26,8 @@ MAKEFILE = Path(__file__).resolve().parent.parent / "Makefile"
 # immediately-expanded variable assignment such as `VAR := value`).
 TARGET_RE = re.compile(r"^([A-Za-z0-9_][A-Za-z0-9_.-]*)\s*:(?!=)")
 PHONY_RE = re.compile(r"^\.PHONY\s*:(.*)$")
+# Targets the Makefile declares as genuinely building a file of their own name.
+FILE_TARGETS_RE = re.compile(r"^FILE_TARGETS\s*[:?]?=(.*)$")
 
 
 def main() -> int:
@@ -31,10 +35,15 @@ def main() -> int:
 
     targets: list[str] = []
     declared: list[str] = []
+    file_targets: list[str] = []
     for line in text.splitlines():
         phony = PHONY_RE.match(line)
         if phony:
             declared.extend(phony.group(1).split())
+            continue
+        file_decl = FILE_TARGETS_RE.match(line)
+        if file_decl:
+            file_targets.extend(file_decl.group(1).split())
             continue
         target = TARGET_RE.match(line)
         if target:
@@ -42,7 +51,7 @@ def main() -> int:
 
     problems: list[str] = []
 
-    undeclared = [t for t in targets if t not in declared]
+    undeclared = [t for t in targets if t not in declared and t not in file_targets]
     if undeclared:
         problems.append(
             "targets missing from .PHONY (make will skip these if a file of "
@@ -53,13 +62,24 @@ def main() -> int:
     if orphaned:
         problems.append(f".PHONY names that are not targets: {' '.join(orphaned)}")
 
+    both = [t for t in file_targets if t in declared]
+    if both:
+        problems.append(
+            "declared in FILE_TARGETS and in .PHONY; a target that builds a "
+            f"file of its own name must not be phony: {' '.join(both)}"
+        )
+
+    unknown = [t for t in file_targets if t not in targets]
+    if unknown:
+        problems.append(f"FILE_TARGETS names that are not targets: {' '.join(unknown)}")
+
     # A target name that also exists as a path is the case .PHONY exists to
     # handle, so it is worth failing on whatever put the path there. This
     # matches untracked files too, which is deliberate: make skips a
     # non-phony target just as readily for a local stray directory as for a
     # committed one. It does not prove the target built that path.
     root = MAKEFILE.parent
-    collide = [t for t in targets if (root / t).exists()]
+    collide = [t for t in targets if t not in file_targets and (root / t).exists()]
     if collide:
         problems.append(
             "target names that also exist as a path in the working tree, "

--- a/scripts/check_phony.py
+++ b/scripts/check_phony.py
@@ -1,0 +1,82 @@
+"""Check that the Makefile's .PHONY line matches the targets it defines.
+
+A target is phony when running it produces no file named after the target.
+Every target in this Makefile is phony, so .PHONY should list all of them
+and nothing else.
+
+checkmake's rule of the same name does not check this: its `phonydeclared`
+only fires on targets with an empty recipe body, so it passes a Makefile
+whose .PHONY line omits every target that actually has a recipe. See
+docs/makefile-phony.md.
+
+Run via `make check-phony`, which `make lint` calls.
+"""
+
+from __future__ import annotations
+
+import re
+import sys
+from pathlib import Path
+
+MAKEFILE = Path(__file__).resolve().parent.parent / "Makefile"
+
+# A target line: name, then ':' not followed by '=' (which would be an
+# immediately-expanded variable assignment such as `VAR := value`).
+TARGET_RE = re.compile(r"^([A-Za-z0-9_][A-Za-z0-9_.-]*)\s*:(?!=)")
+PHONY_RE = re.compile(r"^\.PHONY\s*:(.*)$")
+
+
+def main() -> int:
+    text = MAKEFILE.read_text()
+
+    targets: list[str] = []
+    declared: list[str] = []
+    for line in text.splitlines():
+        phony = PHONY_RE.match(line)
+        if phony:
+            declared.extend(phony.group(1).split())
+            continue
+        target = TARGET_RE.match(line)
+        if target:
+            targets.append(target.group(1))
+
+    problems: list[str] = []
+
+    undeclared = [t for t in targets if t not in declared]
+    if undeclared:
+        problems.append(
+            "targets missing from .PHONY (make will skip these if a file of "
+            f"the same name appears): {' '.join(undeclared)}"
+        )
+
+    orphaned = [d for d in declared if d not in targets]
+    if orphaned:
+        problems.append(f".PHONY names that are not targets: {' '.join(orphaned)}")
+
+    # The other half of the rule: a target that really does build a file of
+    # its own name must not be phony. We cannot read recipes, but a target
+    # name existing as a path is the signal worth failing on.
+    root = MAKEFILE.parent
+    collide = [t for t in targets if (root / t).exists()]
+    if collide:
+        problems.append(
+            "target names that exist as a path, so they may build a file of "
+            f"their own name and should not be phony: {' '.join(collide)}"
+        )
+
+    duplicates = sorted({t for t in targets if targets.count(t) > 1})
+    if duplicates:
+        problems.append(f"targets defined more than once: {' '.join(duplicates)}")
+
+    if problems:
+        print("Makefile .PHONY check failed:", file=sys.stderr)
+        for problem in problems:
+            print(f"  - {problem}", file=sys.stderr)
+        return 1
+
+    print(f".PHONY check passed: {len(targets)} targets, all declared")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/scripts/check_phony.py
+++ b/scripts/check_phony.py
@@ -53,15 +53,18 @@ def main() -> int:
     if orphaned:
         problems.append(f".PHONY names that are not targets: {' '.join(orphaned)}")
 
-    # The other half of the rule: a target that really does build a file of
-    # its own name must not be phony. We cannot read recipes, but a target
-    # name existing as a path is the signal worth failing on.
+    # A target name that also exists as a path is the case .PHONY exists to
+    # handle, so it is worth failing on whatever put the path there. This
+    # matches untracked files too, which is deliberate: make skips a
+    # non-phony target just as readily for a local stray directory as for a
+    # committed one. It does not prove the target built that path.
     root = MAKEFILE.parent
     collide = [t for t in targets if (root / t).exists()]
     if collide:
         problems.append(
-            "target names that exist as a path, so they may build a file of "
-            f"their own name and should not be phony: {' '.join(collide)}"
+            "target names that also exist as a path in the working tree, "
+            "tracked or not; keep them phony, or rename the target if it is "
+            f"meant to build that path: {' '.join(collide)}"
         )
 
     duplicates = sorted({t for t in targets if targets.count(t) > 1})


### PR DESCRIPTION
## Why

Closes https://github.com/microbiomedata/nmdc-metadata-suggestor-ai-tool/issues/115.

The `.PHONY` line listed 17 names while the Makefile defines 23 targets. A phony target that is
not declared gets skipped whenever a file of the same name exists, and make says
`make: 'run' is up to date.` rather than failing, so the skip is silent.

The issue asked to wait for the docker direction to settle first. It has:
https://github.com/microbiomedata/nmdc-metadata-suggestor-ai-tool/pull/104 merged on 2026-07-10.

## What changed

Six real targets added to `.PHONY`: `all-install`, `prod-install`, `docker-dev-build`,
`docker-dev-down`, `docker-shell`, `run`. One name removed, `lint-fix`, which is not a target.

The rule used: a target is phony when running it produces no file named after the target. All 23
targets qualify. None writes an artifact of its own name, and no target name collides with a path
in the repo.

Second commit adds `make check-phony`, called by `make lint`, so the line cannot drift quietly
again. It fails on a target missing from `.PHONY`, a `.PHONY` entry that is not a target, a target
name that exists as a path, or a duplicate target.

## Validation

Behaviour, not just text. With files named `run`, `all-install` and `docker-shell` planted in the
tree, `make -n <target>`:

| target | before | after |
|---|---|---|
| `run` | `make: 'run' is up to date.` | `uv run nmdc-suggestor` |
| `all-install` | `make: 'all-install' is up to date.` | `uv sync` |
| `docker-shell` | `make: 'docker-shell' is up to date.` | `docker-compose exec app bash` |

The check was tested against each failure mode it claims to catch (undeclared target, stale
`.PHONY` entry, target name existing as a path) and fails on each.

`make lint` clean: ruff, mypy on 51 source files, and the new check. `make test`: 257 passed,
57 deselected.

## On checkmake

checkmake is the obvious off-the-shelf linter for this and it ships a rule named `phonydeclared`,
so it looks like it would have caught this. It would not. From its source, the condition is
`len(rule.Body) == 0 && !ok`: it only fires on targets with no recipe body. Every target here has
one, so checkmake reports zero violations against the exact file this PR fixes. Its other phony
rule, `minphony`, only checks that a configured list (default `all,clean,test`) is present.

That is why this is a local check rather than a new dependency. Recorded in
`docs/makefile-phony.md` so the evaluation is not repeated.

## Documentation impact

New `docs/makefile-phony.md`: the rule, what the check enforces, and what to do when adding a
target.

## Scope and complexity

Small. One line of Makefile plus a target, an 82-line script with no dependencies, and a doc.

Three broken targets turned up while verifying this, all pre-existing and left alone here to keep
the PR reviewable. Filed separately:

- https://github.com/microbiomedata/nmdc-metadata-suggestor-ai-tool/issues/154 the five DOI targets use the pre-rename package path `nmdc_metadata_suggestor`
- https://github.com/microbiomedata/nmdc-metadata-suggestor-ai-tool/issues/155 six `docker-*` targets reference files that PR 104 deleted
- https://github.com/microbiomedata/nmdc-metadata-suggestor-ai-tool/issues/156 `run` calls a console script that `pyproject.toml` does not define

Completing `.PHONY` is what makes 155 and 156 reachable, since those targets were being skipped as
up to date.

