### PR TITLE
Type-check tests as well as src

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -41,7 +41,7 @@ jobs:
         uv run ruff format --check
 
     - name: Run type checking
-      run: uv run mypy src
+      run: uv run mypy src tests
 
     - name: Check dependency hygiene
       run: make check-deps

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -55,7 +55,7 @@ make test
 # Or individually:
 uv run ruff format     # Format code
 uv run ruff check      # Lint code
-uv run mypy src        # Type check
+uv run mypy src tests  # Type check
 uv run pytest          # Run tests
 ```
 

--- a/Makefile
+++ b/Makefile
@@ -34,7 +34,7 @@ test-integration: ## Run integration tests against real APIs
 
 lint: ## Run linters
 	uv run ruff check
-	uv run mypy src
+	uv run mypy src tests
 	$(MAKE) check-phony
 
 check-phony: ## Verify .PHONY lists exactly the targets the Makefile defines

--- a/tests/test_abstract_retriever.py
+++ b/tests/test_abstract_retriever.py
@@ -167,7 +167,7 @@ class TestGetAbstractClassificationGate:
         _mock_classify_as_dataset(doi)
         result = get_doi_description_or_abstract(doi)
         assert result.context is None
-        assert "not a publication" in result.error
+        assert result.error is not None and "not a publication" in result.error
 
     @responses.activate
     def test_datacite_software_refused(self) -> None:
@@ -176,8 +176,8 @@ class TestGetAbstractClassificationGate:
         _mock_classify_as_datacite_software(doi)
         result = get_doi_description_or_abstract(doi)
         assert result.context is None
-        assert "Software" in result.error
-        assert "not a publication type" in result.error
+        assert result.error is not None and "Software" in result.error
+        assert result.error is not None and "not a publication type" in result.error
 
     @responses.activate
     def test_crossref_component_refused(self) -> None:
@@ -186,8 +186,8 @@ class TestGetAbstractClassificationGate:
         _mock_classify_as_crossref_component(doi)
         result = get_doi_description_or_abstract(doi)
         assert result.context is None
-        assert "component" in result.error
-        assert "not a publication type" in result.error
+        assert result.error is not None and "component" in result.error
+        assert result.error is not None and "not a publication type" in result.error
 
     @responses.activate
     def test_skip_classification_bypasses_gate(self) -> None:
@@ -252,6 +252,7 @@ class TestGetAbstractWaterfall:
         assert result.source == "osti"
         assert result.publication_urls is not None
         assert str(result.publication_urls[0]) == pdf_url
+        assert result.publication_dois is not None
         assert result.publication_dois[0] == publication_dois
 
     @responses.activate
@@ -530,6 +531,7 @@ class TestContentFormatClassification:
         assert result.context == "Hello world"
         import json
 
+        assert result.raw_context is not None
         assert json.loads(result.raw_context) == inverted
 
 
@@ -735,7 +737,7 @@ def test_get_abstract_real_dataset_doi() -> None:
     result = get_doi_description_or_abstract("10.15485/1729719")
     assert result.context is None
     assert result.error is not None
-    assert "not a publication" in result.error
+    assert result.error is not None and "not a publication" in result.error
 
 
 @integration

--- a/tests/test_agentic.py
+++ b/tests/test_agentic.py
@@ -7,6 +7,7 @@ Run with: uv run pytest -m integration tests/test_agentic.py
 import asyncio
 import json
 from pathlib import Path
+from typing import Any
 
 import pytest
 
@@ -20,9 +21,10 @@ FIXTURES = Path(__file__).parent / "fixtures"
 INTEGRATION_TIMEOUT = 180  # seconds
 
 
-def _load(filename: str) -> dict:
+def _load(filename: str) -> dict[str, Any]:
     with (FIXTURES / filename).open() as f:
-        return json.load(f)
+        data: dict[str, Any] = json.load(f)
+        return data
 
 
 def _make_conversation_manager(prompt: str) -> ConversationManager:
@@ -30,7 +32,7 @@ def _make_conversation_manager(prompt: str) -> ConversationManager:
     return ConversationManager(llm_client=client, system_prompt=prompt)
 
 
-def _assert_valid_output(result: object) -> LLMOutput:
+def _assert_valid_output(result: tuple[Any, Any] | None) -> LLMOutput:
     assert result is not None, "agentic() returned None"
     structured, session_id = result
     assert session_id is not None, "Expected a session_id to be returned"

--- a/tests/test_doi_ingestion.py
+++ b/tests/test_doi_ingestion.py
@@ -136,7 +136,9 @@ XML_PAYLOAD_FIXTURES = _load_xml_payload_fixtures()
 def _load_json_payload_fixtures() -> dict[str, Any]:
     """Load reusable JSON payload fixtures used by resolver tests."""
     with open(JSON_PAYLOAD_FIXTURE_PATH) as f:
-        return json.load(f)["payloads"]
+        data: dict[str, Any] = json.load(f)
+        payloads: dict[str, Any] = data["payloads"]
+        return payloads
 
 
 def _replace_payload_placeholders(value: Any, replacements: dict[str, str]) -> Any:

--- a/tests/test_doi_utils.py
+++ b/tests/test_doi_utils.py
@@ -6,6 +6,7 @@ Unit tests mock HTTP with ``responses``; integration tests hit real APIs.
 
 import json
 from pathlib import Path
+from typing import Any
 from unittest.mock import Mock
 
 import pytest
@@ -34,7 +35,9 @@ integration = pytest.mark.integration
 def test_cases() -> list[dict[str, object]]:
     """Load the curated DOI test cases."""
     with open(FIXTURE_PATH) as f:
-        return json.load(f)["test_cases"]
+        data: dict[str, Any] = json.load(f)
+        cases: list[dict[str, object]] = data["test_cases"]
+        return cases
 
 
 # ---------------------------------------------------------------------------

--- a/tests/test_env_triad_recommendation.py
+++ b/tests/test_env_triad_recommendation.py
@@ -1,4 +1,5 @@
 from pathlib import Path
+from typing import Any
 
 import pytest
 
@@ -8,49 +9,54 @@ from nmdc_metadata_suggestor_ai_tool.llm_client import LLMClient
 pytestmark = pytest.mark.integration
 
 
-def load_sample_submission_object() -> dict:
+def load_sample_submission_object() -> dict[str, Any]:
     """Load a sample submission object from the test fixtures."""
     import json
 
     sample_path = Path(__file__).parent / "fixtures" / "test_submission.json"
     with open(sample_path) as f:
-        return json.load(f)
+        data: dict[str, Any] = json.load(f)
+        return data
 
 
-def load_biosample_object() -> dict:
+def load_biosample_object() -> dict[str, Any]:
     """Load a sample biosample object from the test fixtures."""
     import json
 
     sample_path = Path(__file__).parent / "fixtures" / "biosample.json"
     with open(sample_path) as f:
-        return json.load(f)
+        data: dict[str, Any] = json.load(f)
+        return data
 
 
-def load_bioscales_object() -> dict:
+def load_bioscales_object() -> dict[str, Any]:
     """Load 100 bioscales biosample objects from the test fixtures."""
     import json
 
     sample_path = Path(__file__).parent / "fixtures" / "bioscales_biosamples.json"
     with open(sample_path) as f:
-        return json.load(f)
+        data: dict[str, Any] = json.load(f)
+        return data
 
 
-def load_study_object() -> dict:
+def load_study_object() -> dict[str, Any]:
     """Load bioscales study object from the test fixtures."""
     import json
 
     sample_path = Path(__file__).parent / "fixtures" / "bioscales_study.json"
     with open(sample_path) as f:
-        return json.load(f)
+        data: dict[str, Any] = json.load(f)
+        return data
 
 
-def load_full_submission() -> dict:
+def load_full_submission() -> dict[str, Any]:
     """Load full submission object from the test fixtures."""
     import json
 
     sample_path = Path(__file__).parent / "fixtures" / "full_submission.json"
     with open(sample_path) as f:
-        return json.load(f)
+        data: dict[str, Any] = json.load(f)
+        return data
 
 
 def test_run_env_triad_pipeline(requires_credentials: None) -> None:
@@ -58,7 +64,7 @@ def test_run_env_triad_pipeline(requires_credentials: None) -> None:
     llm_client = LLMClient(access_provider="gcp")
     recommended_metadata = env_triad_recommendation.get_env_triad_recommendation(
         submission_object=sample_submission_object,
-        samples=sample_submission_object.get("metadata_submission").get("sampleData")["soil_data"],
+        samples=sample_submission_object["metadata_submission"]["sampleData"]["soil_data"],
         interface_names=["soil"],
         llm_client=llm_client,
     )
@@ -87,7 +93,7 @@ def test_run_env_triad_pipeline_with_biosample(requires_credentials: None) -> No
 
 def test_run_env_triad_pipeline_with_bioscales(requires_credentials: None) -> None:
     llm_client = LLMClient(access_provider="gcp")
-    biosample_objects = load_bioscales_object().get("resources")
+    biosample_objects = load_bioscales_object()["resources"]
     study_object = load_study_object()
     recommended_metadata = env_triad_recommendation.get_env_triad_recommendation(
         study_context=[study_object],
@@ -98,7 +104,7 @@ def test_run_env_triad_pipeline_with_bioscales(requires_credentials: None) -> No
 
     print(recommended_metadata.model_dump())
     # Ensure each sample id appears somewhere in the recommendations
-    sample_ids = [s.get("id") for s in biosample_objects]
+    sample_ids = [s["id"] for s in biosample_objects]
 
     for sid in sample_ids:
         assert sid in {f.id for f in recommended_metadata.metadata_fields}, (
@@ -119,7 +125,7 @@ def test_run_env_triad_pipeline_with_bioscales(requires_credentials: None) -> No
 def test_run_env_triad_pipeline_with_submission_samples(requires_credentials: None) -> None:
     llm_client = LLMClient(access_provider="gcp")
     submission_object = load_full_submission()
-    samples = submission_object.get("metadata_submission").get("sampleData")["water_data"][:10]
+    samples = submission_object["metadata_submission"]["sampleData"]["water_data"][:10]
     # pop env_medium, env_broad_scale, and env_local_scale from the samples
     for sample in samples:
         sample.pop("env_medium", None)
@@ -137,7 +143,7 @@ def test_run_env_triad_pipeline_with_submission_samples(requires_credentials: No
     print(recommended_metadata.model_dump())
 
     # get a unique list of ids from the LLM output
-    ids = {f.id for f in recommended_metadata.metadata_fields}
+    ids = {f.id for f in recommended_metadata.metadata_fields if f.id is not None}
     # in this case we know there is 10 samples -> so the ids should be 0-9
     truth_ids = [str(x) for x in sorted(range(10))]
     # assert the ids are 0-9

--- a/tests/test_llm_client.py
+++ b/tests/test_llm_client.py
@@ -3,6 +3,7 @@
 from typing import Any
 
 import pytest
+from openai import OpenAI
 
 from nmdc_metadata_suggestor_ai_tool.llm_client import (
     DEFAULT_MAX_TOKENS_BY_PROVIDER,
@@ -87,6 +88,7 @@ def test_cborg_client_reads_env_at_initialization_time(monkeypatch: Any) -> None
     client = LLMClient(access_provider="cborg")
 
     assert client.model == "gemini-2.5-flash"
+    assert isinstance(client.client, OpenAI)
     assert str(client.client.base_url).rstrip("/") == "https://api.cborg.lbl.gov"
 
 

--- a/tests/test_osti_publication_retriever.py
+++ b/tests/test_osti_publication_retriever.py
@@ -94,6 +94,7 @@ def test_try_osti_uses_osti_pdf_link_for_journal_article() -> None:
     assert result.text == abstract_text
     assert result.raw_text == abstract_text
     assert result.urls == [pdf_url]
+    assert result.publication_dois is not None
     assert result.publication_dois[0] == journal_article_doi
     assert result.source == "osti"
 
@@ -125,6 +126,7 @@ def test_try_osti_pdf_link_without_description_returns_context_with_empty_text()
     assert result.text is None
     assert result.raw_text is None
     assert result.urls == [pdf_url]
+    assert result.publication_dois is not None
     assert result.publication_dois[0] == journal_article_doi
     assert any("No abstract/description found" in error for error in errors)
     assert not any("no abstract/description or pdf link" in error.lower() for error in errors)

--- a/tests/test_recommendation_pipeline.py
+++ b/tests/test_recommendation_pipeline.py
@@ -1,6 +1,7 @@
 import time
 from pathlib import Path
 from types import SimpleNamespace
+from typing import Any, cast
 
 import pytest
 
@@ -9,15 +10,18 @@ from nmdc_metadata_suggestor_ai_tool.llm_client import LLMClient
 from nmdc_metadata_suggestor_ai_tool.utils import build_submission_context
 
 
-def load_sample_submission_object() -> dict:
+def load_sample_submission_object() -> dict[str, Any]:
     """Load a sample submission object from the test fixtures."""
     import json
 
     sample_path = Path(__file__).parent / "fixtures" / "test_submission.json"
     with open(sample_path) as f:
-        return json.load(f)
+        data: dict[str, Any] = json.load(f)
+        return data
 
 
+# Duck-types LLMClient for the pipeline's purposes. Call sites cast rather than
+# subclass, so the fake does not inherit LLMClient's credential setup.
 class _FakeLLMClient:
     def __init__(self, response: str) -> None:
         self.response = response
@@ -70,7 +74,7 @@ def test_run_recommendation_pipeline_validates_and_returns_output(
 
     result = recommendation_pipeline.run_recommendation_pipeline(
         submission_object=sample_submission_object,
-        llm_client=client,
+        llm_client=cast(LLMClient, client),
     )
 
     assert result.metadata_fields[0].field_name == "env_broad_scale"
@@ -90,7 +94,7 @@ def test_run_recommendation_pipeline_raises_for_invalid_output_schema(
     with pytest.raises(ValueError, match="expected output schema"):
         recommendation_pipeline.run_recommendation_pipeline(
             submission_object=sample_submission_object,
-            llm_client=client,
+            llm_client=cast(LLMClient, client),
         )
 
 
@@ -100,7 +104,7 @@ _VALID_RESPONSE = (
 )
 
 
-def _spy_on_schema_context(monkeypatch: pytest.MonkeyPatch) -> dict:
+def _spy_on_schema_context(monkeypatch: pytest.MonkeyPatch) -> dict[str, Any]:
     """Stub the network abstract lookup and capture the class names that the
     pipeline hands to ``format_multi_interface_context``.
 
@@ -141,7 +145,7 @@ def test_interface_name_resolves_to_interface_class_names(
 
     recommendation_pipeline.run_recommendation_pipeline(
         submission_object=load_sample_submission_object(),
-        llm_client=client,
+        llm_client=cast(LLMClient, client),
         interface_name="soil",
     )
 
@@ -161,7 +165,7 @@ def test_interface_name_accepts_interface_class_name_form(
 
     recommendation_pipeline.run_recommendation_pipeline(
         submission_object=load_sample_submission_object(),
-        llm_client=client,
+        llm_client=cast(LLMClient, client),
         interface_name="SoilInterface",
     )
 
@@ -187,7 +191,7 @@ def test_interface_name_does_not_crash_schema_context_builder(
 
     result = recommendation_pipeline.run_recommendation_pipeline(
         submission_object=load_sample_submission_object(),
-        llm_client=client,
+        llm_client=cast(LLMClient, client),
         interface_name="soil",
     )
 
@@ -208,7 +212,7 @@ def test_interface_name_overrides_submission_package(
 
     recommendation_pipeline.run_recommendation_pipeline(
         submission_object=load_sample_submission_object(),
-        llm_client=client,
+        llm_client=cast(LLMClient, client),
         interface_name="water",
     )
 
@@ -229,7 +233,7 @@ def test_absent_interface_name_falls_back_to_submission_package(
 
     recommendation_pipeline.run_recommendation_pipeline(
         submission_object=load_sample_submission_object(),
-        llm_client=client,
+        llm_client=cast(LLMClient, client),
         interface_name=interface_name,
     )
 

--- a/tests/test_schema_context.py
+++ b/tests/test_schema_context.py
@@ -92,6 +92,7 @@ def test_extract_slot_enum_values_for_llm_context() -> None:
     builder = SchemaContextBuilder()
     schema = builder.get_interface_schema("SoilInterface")
     env_medium = next(s for s in schema.slots if s.name == "env_medium")
+    assert env_medium.enum_values is not None
     assert len(env_medium.enum_values) > 0
     terms = [
         f"- {ev.text}: {ev.description}" if ev.description else f"- {ev.text}"

--- a/tests/test_submission_parser.py
+++ b/tests/test_submission_parser.py
@@ -1,6 +1,7 @@
 import json
 import logging
 from pathlib import Path
+from typing import Any
 
 import pytest
 
@@ -12,9 +13,10 @@ from nmdc_metadata_suggestor_ai_tool.utils.submission_parser import (
 FIXTURES_DIR = Path(__file__).parent / "fixtures"
 
 
-def _load_fixture(filename: str) -> dict:
+def _load_fixture(filename: str) -> dict[str, Any]:
     with (FIXTURES_DIR / filename).open() as fixture_file:
-        return json.load(fixture_file)
+        data: dict[str, Any] = json.load(fixture_file)
+        return data
 
 
 def test_get_submission_fields_extracts_protocol_metadata_from_fixture() -> None:

--- a/tests/test_supplement_retrieval.py
+++ b/tests/test_supplement_retrieval.py
@@ -4,6 +4,7 @@ import io
 import os
 import tempfile
 import zipfile
+from pathlib import Path
 from urllib.parse import quote
 
 import pytest
@@ -194,7 +195,7 @@ def test_select_members_spends_max_total_bytes_on_data_like_kinds() -> None:
     assert [f.filename for f in kept] == ["Table_S1.csv"]
 
 
-def test_select_members_keeps_colliding_basenames_apart(tmp_path) -> None:
+def test_select_members_keeps_colliding_basenames_apart(tmp_path: Path) -> None:
     # Two members share a basename (one nested in an archive). With save_dir set
     # they must not write to the same path, or the first file's bytes are lost
     # and both results point at the second.
@@ -212,9 +213,10 @@ def test_select_members_keeps_colliding_basenames_apart(tmp_path) -> None:
         captions=None,
     )
     paths = [f.saved_path for f in kept]
+    assert all(p is not None for p in paths)
     assert len(paths) == 2
     assert len(set(paths)) == 2, "colliding basenames overwrote each other"
-    assert {open(p, "rb").read() for p in paths} == {b"aaaa", b"bbbb"}
+    assert {Path(str(p)).read_bytes() for p in paths} == {b"aaaa", b"bbbb"}
 
 
 def test_parse_supplement_captions() -> None:
@@ -873,7 +875,7 @@ def test_orchestrator_shares_budget_across_sources() -> None:
 # ---------------------------------------------------------------------------
 
 
-def test_merge_results_deletes_trimmed_temp_files(tmp_path) -> None:
+def test_merge_results_deletes_trimmed_temp_files(tmp_path: Path) -> None:
     from nmdc_metadata_suggestor_ai_tool.models.supplement import (
         SupplementFile,
         SupplementRetrievalResult,
@@ -988,7 +990,7 @@ def test_merge_results_keeps_same_basename_from_one_source() -> None:
     assert len(deduped.files) == 2
 
 
-def test_merge_results_keeps_user_managed_files(tmp_path) -> None:
+def test_merge_results_keeps_user_managed_files(tmp_path: Path) -> None:
     # With save_dir=..., the saved paths are caller-owned outputs: trimming a file
     # from the merged result must not delete it.
     from nmdc_metadata_suggestor_ai_tool.models.supplement import (
@@ -1001,7 +1003,7 @@ def test_merge_results_keeps_user_managed_files(tmp_path) -> None:
     dropped_path = save_dir / "dropped.pdf"
     dropped_path.write_bytes(b"%PDF-1.4 dropped")
 
-    def _result(source: str, name: str, path) -> SupplementRetrievalResult:
+    def _result(source: str, name: str, path: Path) -> SupplementRetrievalResult:
         return SupplementRetrievalResult(
             doi="x",
             source=source,
@@ -1032,7 +1034,9 @@ def test_merge_results_keeps_user_managed_files(tmp_path) -> None:
     assert dropped_path.exists()  # caller-managed output left in place
 
 
-def test_is_removable_temp_file_rejects_paths_outside_temp(tmp_path, monkeypatch) -> None:
+def test_is_removable_temp_file_rejects_paths_outside_temp(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
     # Pin the temp root rather than probing the real one: a checkout that itself
     # lives under /tmp would otherwise make every path look removable.
     temp_root = tmp_path / "tmproot"
@@ -1162,7 +1166,7 @@ LIVE_DRYAD_DOI = "10.5061/dryad.51c59zwfj"  # Zenodo-mirrored dataset with .csv 
 LIVE_EUROPEPMC_DOI = "10.1186/s40168-018-0605-2"
 
 
-def _assert_live_result(result, source: str) -> None:
+def _assert_live_result(result: object, source: str) -> None:
     from nmdc_metadata_suggestor_ai_tool.models.supplement import SupplementRetrievalResult
 
     assert isinstance(result, SupplementRetrievalResult)

--- a/tests/test_supplement_retrieval_skill.py
+++ b/tests/test_supplement_retrieval_skill.py
@@ -18,7 +18,9 @@ import asyncio
 import importlib
 import inspect
 import re
+from collections.abc import Callable
 from pathlib import Path
+from typing import Any
 
 import pytest
 
@@ -94,7 +96,7 @@ def test_documented_retrieve_supplements_signature_matches() -> None:
     assert "doi" in documented
 
 
-def test_documented_source_names_route_to_a_retriever(monkeypatch) -> None:
+def test_documented_source_names_route_to_a_retriever(monkeypatch: pytest.MonkeyPatch) -> None:
     # SKILL.md tells the agent it may pass sources=["europepmc", ...]. Each name
     # must reach a retriever rather than being silently ignored.
     skill = (SKILL_DIR / "SKILL.md").read_text()
@@ -105,8 +107,8 @@ def test_documented_source_names_route_to_a_retriever(monkeypatch) -> None:
 
     called: list[str] = []
 
-    def _recorder(name: str):
-        def _retrieve(doi: str, **kwargs) -> SupplementRetrievalResult:
+    def _recorder(name: str) -> Callable[..., SupplementRetrievalResult]:
+        def _retrieve(doi: str, **kwargs: Any) -> SupplementRetrievalResult:
             called.append(name)
             return SupplementRetrievalResult(doi=doi, source=name, attempts=[name])
 

--- a/tests/test_vertexai_integration.py
+++ b/tests/test_vertexai_integration.py
@@ -7,6 +7,7 @@ to confirm that the VertexAI endpoint is reachable and produces valid output.
 
 import json
 from pathlib import Path
+from typing import Any
 
 import pytest
 
@@ -22,10 +23,11 @@ FIXTURES_DIR = Path(__file__).parent / "fixtures"
 INTEGRATION_TIMEOUT = 120  # seconds
 
 
-def _load_fixture(filename: str) -> dict:
+def _load_fixture(filename: str) -> dict[str, Any]:
     """Load a JSON fixture by filename."""
     with (FIXTURES_DIR / filename).open() as f:
-        return json.load(f)
+        data: dict[str, Any] = json.load(f)
+        return data
 
 
 @pytest.mark.timeout(INTEGRATION_TIMEOUT)


### PR DESCRIPTION
## Why

Closes https://github.com/microbiomedata/nmdc-metadata-suggestor-ai-tool/issues/102, scoped by
@hesspnnl on 2026-08-21 as "add the test dir to type checking, update tests as needed".

## What changed

mypy's scope now includes `tests` in three places: the `Makefile` lint target, `CONTRIBUTING.md`,
and `.github/workflows/ci.yml`.

The CI one is the change that actually does anything. `ci.yml` calls `uv run mypy src` directly
rather than going through `make lint`, so editing only the Makefile would have left CI checking
`src` alone and the scope extension would have been cosmetic.

Turning it on produced 48 errors, all in `tests`. `src` was already clean. They are fixed rather
than suppressed: nothing was added to an ignore list, no rule was relaxed, and
`disallow_untyped_defs` still applies to tests the same as to source.

## The fixes, by shape

- **Fixture loaders** declared `-> dict` and returned `json.load(f)`, which is `Any`. They now
  declare `-> dict[str, Any]` and annotate the loaded value.
- **`.get()` chains on fixture keys that are always present** became direct indexing. `.get()`
  returns `Any | None` and every one of these was immediately dereferenced, so the `Optional` was
  never real.
- **Optionals that tests dereference** are asserted non-None first. This also makes the assumption
  visible in the failure output when a fixture changes shape.
- **`_FakeLLMClient`** is cast to `LLMClient` at the seven call sites rather than subclassing it,
  so the fake does not inherit `LLMClient`'s credential setup. A comment at the class says so.
- **Missing annotations** on pytest fixture parameters (`tmp_path`, `monkeypatch`) and two inner
  helpers.

## Validation

`ruff check`, `ruff format --check` on 87 files, `mypy src tests` on 69 source files, and
`pytest`: 257 passed, 57 deselected. Same 257 as before the change.

## Documentation impact

`CONTRIBUTING.md`'s type-check command updated to match.

## Scope and complexity

Mechanical. 87 insertions, 53 deletions across 13 test files plus three one-line config changes.
No source file touched.

Note for whoever merges second: this and
https://github.com/microbiomedata/nmdc-metadata-suggestor-ai-tool/pull/153 both edit the
`Makefile` lint target, on adjacent lines. Either may need a trivial rebase.
