### PR TITLE
Guard untrusted XML at the parser, and fix the JATS documents it was refusing

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -44,6 +44,7 @@ CONTACT_EMAIL=support@microbiomedata.org
 # Safety limits on characters read from untrusted XML payloads in DOI resolvers
 NMDC_EDI_MAX_XML_CHARS=2000000
 NMDC_DATAONE_SOLR_MAX_XML_CHARS=2000000
+NMDC_EUROPEPMC_MAX_XML_CHARS=2000000
 # HTTP retry and connection-pool settings for publication/DOI requests
 NMDC_HTTP_RETRY_ATTEMPTS=3
 NMDC_HTTP_RETRY_BACKOFF_SECONDS=0

--- a/README.md
+++ b/README.md
@@ -170,6 +170,7 @@ Advanced ingestion tuning (all optional; defaults shown):
 
 - `NMDC_EDI_MAX_XML_CHARS`: Max characters read from an untrusted EDI metadata XML payload (default `2000000`).
 - `NMDC_DATAONE_SOLR_MAX_XML_CHARS`: Max characters read from an untrusted DataONE Solr XML payload (default `2000000`).
+- `NMDC_EUROPEPMC_MAX_XML_CHARS`: Max characters read from an untrusted Europe PMC full text XML payload (default `2000000`).
 - `NMDC_HTTP_RETRY_ATTEMPTS`: Retry attempts for publication/DOI HTTP requests (default `3`).
 - `NMDC_HTTP_RETRY_BACKOFF_SECONDS`: Base backoff in seconds between retries (default `0`).
 - `NMDC_HTTP_MAX_RETRY_DELAY_SECONDS`: Cap in seconds on retry delay (default `30`).

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -31,6 +31,7 @@ dependencies = [
     "langfuse==4.14.0",
     "opentelemetry-sdk==1.43.0",
     "openinference-instrumentation-claude-agent-sdk==0.1.7",
+    "defusedxml>=0.7.1",
 ]
 
 [project.urls]
@@ -48,6 +49,7 @@ dev = [
     "mypy>=1.8.0",
     "responses>=0.25.0",
     "types-requests>=2.31.0",
+    "types-defusedxml>=0.7.0.20260504",
 ]
 
 [build-system]

--- a/src/nmdc_metadata_suggestor_ai_tool/constants.py
+++ b/src/nmdc_metadata_suggestor_ai_tool/constants.py
@@ -102,6 +102,11 @@ MAX_DATAONE_SOLR_XML_CHARS = int(os.environ.get("NMDC_DATAONE_SOLR_MAX_XML_CHARS
 # measured 2026-08-24, so this leaves roughly 6x headroom over the largest.
 MAX_EUROPEPMC_FULLTEXT_XML_CHARS = int(os.environ.get("NMDC_EUROPEPMC_MAX_XML_CHARS", "2000000"))
 UNSAFE_XML_DECLARATION_PATTERN = re.compile(r"<!\s*(?:DOCTYPE|ENTITY)\b", re.IGNORECASE)
+# A CDATA section holds character data, never markup, so "<!DOCTYPE" inside one
+# is literal text. Blanked before the declaration scan so valid input is not
+# rejected. A real DOCTYPE must precede the root element and therefore cannot
+# sit inside a CDATA section, so this cannot hide one.
+CDATA_SECTION_PATTERN = re.compile(r"<!\[CDATA\[.*?\]\]>", re.DOTALL)
 
 
 # DOI prefixes that indicate the target provider for context retrieval.

--- a/src/nmdc_metadata_suggestor_ai_tool/constants.py
+++ b/src/nmdc_metadata_suggestor_ai_tool/constants.py
@@ -98,6 +98,9 @@ ZENODO_API = "https://zenodo.org/api/records"
 # Safety limits for untrusted XML payloads in DOI resolvers.
 MAX_EDI_METADATA_XML_CHARS = int(os.environ.get("NMDC_EDI_MAX_XML_CHARS", "2000000"))
 MAX_DATAONE_SOLR_XML_CHARS = int(os.environ.get("NMDC_DATAONE_SOLR_MAX_XML_CHARS", "2000000"))
+# Europe PMC full text runs ~36KB to ~307KB across a sample of four articles
+# measured 2026-08-24, so this leaves roughly 6x headroom over the largest.
+MAX_EUROPEPMC_FULLTEXT_XML_CHARS = int(os.environ.get("NMDC_EUROPEPMC_MAX_XML_CHARS", "2000000"))
 UNSAFE_XML_DECLARATION_PATTERN = re.compile(r"<!\s*(?:DOCTYPE|ENTITY)\b", re.IGNORECASE)
 
 

--- a/src/nmdc_metadata_suggestor_ai_tool/constants.py
+++ b/src/nmdc_metadata_suggestor_ai_tool/constants.py
@@ -101,12 +101,6 @@ MAX_DATAONE_SOLR_XML_CHARS = int(os.environ.get("NMDC_DATAONE_SOLR_MAX_XML_CHARS
 # Europe PMC full text runs ~36KB to ~307KB across a sample of four articles
 # measured 2026-08-24, so this leaves roughly 6x headroom over the largest.
 MAX_EUROPEPMC_FULLTEXT_XML_CHARS = int(os.environ.get("NMDC_EUROPEPMC_MAX_XML_CHARS", "2000000"))
-UNSAFE_XML_DECLARATION_PATTERN = re.compile(r"<!\s*(?:DOCTYPE|ENTITY)\b", re.IGNORECASE)
-# A CDATA section holds character data, never markup, so "<!DOCTYPE" inside one
-# is literal text. Blanked before the declaration scan so valid input is not
-# rejected. A real DOCTYPE must precede the root element and therefore cannot
-# sit inside a CDATA section, so this cannot hide one.
-CDATA_SECTION_PATTERN = re.compile(r"<!\[CDATA\[.*?\]\]>", re.DOTALL)
 
 
 # DOI prefixes that indicate the target provider for context retrieval.

--- a/src/nmdc_metadata_suggestor_ai_tool/doi_ingestion/doi_utils.py
+++ b/src/nmdc_metadata_suggestor_ai_tool/doi_ingestion/doi_utils.py
@@ -179,10 +179,10 @@ def append_error(errors: list[str] | None, message: str) -> None:
 def strip_jats_xml(xml_abstract: str) -> str:
     """Strip JATS/XML tags from text and unescape HTML entities.
 
-    The wrapping element is what makes a hostile abstract harmless: a DOCTYPE
-    inside it is invalid XML, and a DOCTYPE is the only entry point for entity
-    expansion. That is emergent rather than intended, so the payload also goes
-    through the shared guard, which rejects the declaration outright.
+    Abstracts come off the network, so the payload goes through the shared
+    guard, which rejects entity declarations and external references. An
+    entity-free DOCTYPE is permitted. The wrapping element is unrelated to
+    safety: JATS abstracts are fragments with no single root, so they need one.
     """
     root, _reason = parse_untrusted_xml(f"<root>{xml_abstract}</root>")
     if root is not None:

--- a/src/nmdc_metadata_suggestor_ai_tool/doi_ingestion/doi_utils.py
+++ b/src/nmdc_metadata_suggestor_ai_tool/doi_ingestion/doi_utils.py
@@ -33,6 +33,7 @@ from nmdc_metadata_suggestor_ai_tool.models.doi import (
     DoiClassification,
     DoiValidation,
 )
+from nmdc_metadata_suggestor_ai_tool.xml_safety import parse_untrusted_xml
 
 DEFAULT_RETRY_ATTEMPTS = int(os.environ.get("NMDC_HTTP_RETRY_ATTEMPTS", "3"))
 # Default backoff is 0 to avoid introducing real sleep delays by default (e.g., in tests).
@@ -176,13 +177,17 @@ def append_error(errors: list[str] | None, message: str) -> None:
 
 
 def strip_jats_xml(xml_abstract: str) -> str:
-    """Strip JATS/XML tags from text and unescape HTML entities."""
-    try:
-        root = ET.fromstring(f"<root>{xml_abstract}</root>")
+    """Strip JATS/XML tags from text and unescape HTML entities.
+
+    The wrapping element is what makes a hostile abstract harmless: a DOCTYPE
+    inside it is invalid XML, and a DOCTYPE is the only entry point for entity
+    expansion. That is emergent rather than intended, so the payload also goes
+    through the shared guard, which rejects the declaration outright.
+    """
+    root, _reason = parse_untrusted_xml(f"<root>{xml_abstract}</root>")
+    if root is not None:
         text = ET.tostring(root, encoding="unicode", method="text")
         return html.unescape(text).strip()
-    except ET.ParseError:
-        pass
 
     text = re.sub(r"<[^>]+>", "", xml_abstract)
     return html.unescape(text).strip()

--- a/src/nmdc_metadata_suggestor_ai_tool/doi_ingestion/ess_dive.py
+++ b/src/nmdc_metadata_suggestor_ai_tool/doi_ingestion/ess_dive.py
@@ -119,7 +119,8 @@ def _parse_dataone_solr_docs(xml_text: str) -> list[dict[str, object]]:
 
     The payload is untrusted, so it is parsed through
     :func:`~nmdc_metadata_suggestor_ai_tool.xml_safety.parse_untrusted_xml`,
-    which rejects oversized payloads and DTD/entity declarations.
+    which rejects oversized payloads, entity declarations and external
+    references. An entity-free DOCTYPE is permitted.
     """
     root, _reason = parse_untrusted_xml(xml_text, max_chars=MAX_DATAONE_SOLR_XML_CHARS)
     if root is None:

--- a/src/nmdc_metadata_suggestor_ai_tool/publication_ingestion/supplements/shared.py
+++ b/src/nmdc_metadata_suggestor_ai_tool/publication_ingestion/supplements/shared.py
@@ -16,7 +16,11 @@ import zipfile
 from collections.abc import Callable, Iterable
 from typing import Any, NamedTuple
 
-from nmdc_metadata_suggestor_ai_tool.constants import DEFAULT_TIMEOUT, USER_AGENT
+from nmdc_metadata_suggestor_ai_tool.constants import (
+    DEFAULT_TIMEOUT,
+    MAX_EUROPEPMC_FULLTEXT_XML_CHARS,
+    USER_AGENT,
+)
 from nmdc_metadata_suggestor_ai_tool.doi_ingestion.doi_utils import (
     normalize_doi,
     request_with_retry,
@@ -181,7 +185,7 @@ def parse_supplement_captions(xml_text: str | bytes) -> dict[str, str]:
         the shared untrusted-XML guards or does not parse.
     """
     captions: dict[str, str] = {}
-    root, _reason = parse_untrusted_xml(xml_text)
+    root, _reason = parse_untrusted_xml(xml_text, max_chars=MAX_EUROPEPMC_FULLTEXT_XML_CHARS)
     if root is None:
         return captions
 

--- a/src/nmdc_metadata_suggestor_ai_tool/xml_safety.py
+++ b/src/nmdc_metadata_suggestor_ai_tool/xml_safety.py
@@ -2,13 +2,28 @@
 
 Every payload this package parses comes off the network, so all of it goes
 through :func:`parse_untrusted_xml` rather than calling ``ElementTree`` directly.
-Keeping the guards in one place means a future hardening change (a stricter
-pattern, a different parser) lands for every caller at once.
+Keeping the guards in one place means a future hardening change lands for every
+caller at once.
+
+The guard is ``defusedxml``, which refuses entity declarations and external
+references inside the parser. It replaced a regex that scanned for
+``<!DOCTYPE``/``<!ENTITY`` before parsing, for two reasons, both measured.
+
+The regex was unsafe. XML comments, CDATA sections and processing instructions
+are lexical regions a regex cannot track across, so a comment could open inside
+a CDATA marker and close after a real declaration, hiding it from the scan while
+ElementTree still parsed and expanded it.
+
+The regex was also too strict to work. A plain ``<!DOCTYPE article`` carries no
+entities and is normal in JATS: three of four Europe PMC full texts sampled on
+2026-08-24 had one, and the scan refused all three, so supplement caption
+extraction silently returned nothing for them.
 """
 
 import xml.etree.ElementTree as ET
 
-from nmdc_metadata_suggestor_ai_tool.constants import UNSAFE_XML_DECLARATION_PATTERN
+from defusedxml.common import DefusedXmlException
+from defusedxml.ElementTree import fromstring as defused_fromstring
 
 
 def parse_untrusted_xml(
@@ -18,9 +33,10 @@ def parse_untrusted_xml(
 ) -> tuple[ET.Element | None, str | None]:
     """Parse untrusted XML, refusing payloads that are oversized or unsafe.
 
-    DOCTYPE/ENTITY declarations are rejected outright: ElementTree does not
-    expand external entities, but it does expand internal ones, so a declaration
-    is the entry point for entity-expansion ("billion laughs") attacks.
+    Entity declarations and external references are refused by the parser, which
+    blocks entity expansion ("billion laughs") and external-entity reads. A
+    document type declaration on its own is allowed, because it is normal in
+    JATS and harmless without entities.
 
     Args:
         xml_text: The document, as text or UTF-8 bytes.
@@ -41,15 +57,10 @@ def parse_untrusted_xml(
 
     if max_chars is not None and len(xml_text) > max_chars:
         return None, "XML exceeded size limit"
-    # Scanned on the raw text, deliberately. Blanking CDATA first, so that a
-    # "<!DOCTYPE" an author quoted is not mistaken for a declaration, is
-    # unsafe: a comment can open inside a CDATA marker and close after a real
-    # declaration, hiding it from any regex that treats those as separate
-    # lexical regions. See test_regex_lexing_cannot_be_made_safe.
-    if UNSAFE_XML_DECLARATION_PATTERN.search(xml_text):
-        return None, "XML contains unsafe declarations"
 
     try:
-        return ET.fromstring(xml_text), None
+        return defused_fromstring(xml_text), None
+    except DefusedXmlException:
+        return None, "XML contains unsafe declarations"
     except ET.ParseError:
         return None, "response was not valid XML"

--- a/src/nmdc_metadata_suggestor_ai_tool/xml_safety.py
+++ b/src/nmdc_metadata_suggestor_ai_tool/xml_safety.py
@@ -8,10 +8,7 @@ pattern, a different parser) lands for every caller at once.
 
 import xml.etree.ElementTree as ET
 
-from nmdc_metadata_suggestor_ai_tool.constants import (
-    CDATA_SECTION_PATTERN,
-    UNSAFE_XML_DECLARATION_PATTERN,
-)
+from nmdc_metadata_suggestor_ai_tool.constants import UNSAFE_XML_DECLARATION_PATTERN
 
 
 def parse_untrusted_xml(
@@ -44,9 +41,12 @@ def parse_untrusted_xml(
 
     if max_chars is not None and len(xml_text) > max_chars:
         return None, "XML exceeded size limit"
-    # Scan with CDATA blanked out: its contents are character data, so a
-    # "<!DOCTYPE" there is text an author wrote, not a declaration.
-    if UNSAFE_XML_DECLARATION_PATTERN.search(CDATA_SECTION_PATTERN.sub("", xml_text)):
+    # Scanned on the raw text, deliberately. Blanking CDATA first, so that a
+    # "<!DOCTYPE" an author quoted is not mistaken for a declaration, is
+    # unsafe: a comment can open inside a CDATA marker and close after a real
+    # declaration, hiding it from any regex that treats those as separate
+    # lexical regions. See test_regex_lexing_cannot_be_made_safe.
+    if UNSAFE_XML_DECLARATION_PATTERN.search(xml_text):
         return None, "XML contains unsafe declarations"
 
     try:

--- a/src/nmdc_metadata_suggestor_ai_tool/xml_safety.py
+++ b/src/nmdc_metadata_suggestor_ai_tool/xml_safety.py
@@ -8,7 +8,10 @@ pattern, a different parser) lands for every caller at once.
 
 import xml.etree.ElementTree as ET
 
-from nmdc_metadata_suggestor_ai_tool.constants import UNSAFE_XML_DECLARATION_PATTERN
+from nmdc_metadata_suggestor_ai_tool.constants import (
+    CDATA_SECTION_PATTERN,
+    UNSAFE_XML_DECLARATION_PATTERN,
+)
 
 
 def parse_untrusted_xml(
@@ -41,7 +44,9 @@ def parse_untrusted_xml(
 
     if max_chars is not None and len(xml_text) > max_chars:
         return None, "XML exceeded size limit"
-    if UNSAFE_XML_DECLARATION_PATTERN.search(xml_text):
+    # Scan with CDATA blanked out: its contents are character data, so a
+    # "<!DOCTYPE" there is text an author wrote, not a declaration.
+    if UNSAFE_XML_DECLARATION_PATTERN.search(CDATA_SECTION_PATTERN.sub("", xml_text)):
         return None, "XML contains unsafe declarations"
 
     try:

--- a/tests/test_xml_safety.py
+++ b/tests/test_xml_safety.py
@@ -211,3 +211,35 @@ def test_blanking_cdata_cannot_hide_a_real_declaration(payload: str) -> None:
     root, reason = parse_untrusted_xml(payload)
     assert root is None
     assert reason == "XML contains unsafe declarations"
+
+
+# --- the size limit must stay wired into the caller, not just exist in the helper ---
+
+
+def test_supplement_caption_parsing_enforces_the_size_limit(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Pins ``max_chars`` into the ``parse_supplement_captions`` call.
+
+    Without this the limit can be deleted from the call site and the whole
+    suite still passes, because every other test uses documents far under it.
+    The order matters: assert the fixture parses to a caption first, otherwise
+    a document that yields nothing for unrelated reasons would satisfy the
+    second assertion whether or not the limit is applied.
+    """
+    from nmdc_metadata_suggestor_ai_tool.publication_ingestion.supplements import shared
+
+    jats = (
+        "<article><body>"
+        '<supplementary-material xlink:href="table1.csv" '
+        'xmlns:xlink="http://www.w3.org/1999/xlink">'
+        "<caption><p>Supplementary table one</p></caption>"
+        "</supplementary-material></body></article>"
+    )
+
+    assert shared.parse_supplement_captions(jats) == {"table1": "Supplementary table one"}, (
+        "the fixture must parse to a caption first, or the assertion below proves nothing"
+    )
+
+    monkeypatch.setattr(shared, "MAX_EUROPEPMC_FULLTEXT_XML_CHARS", 10)
+    assert not shared.parse_supplement_captions(jats)

--- a/tests/test_xml_safety.py
+++ b/tests/test_xml_safety.py
@@ -1,6 +1,5 @@
 """Tests for the shared untrusted-XML parsing guards."""
 
-import xml.etree.ElementTree as ET
 from pathlib import Path
 
 import pytest
@@ -161,30 +160,38 @@ def test_declaration_guard_rejects_payloads_with_and_without_a_wrapper() -> None
 # --- CDATA holds character data, so a declaration inside one is text ---
 
 
-def test_cdata_containing_a_doctype_is_not_rejected() -> None:
-    """An abstract may legitimately quote markup.
+def test_cdata_containing_a_doctype_is_rejected_a_known_false_positive() -> None:
+    """Documents a real false positive we are choosing to keep.
 
-    The declaration scan runs before parsing, so without blanking CDATA first it
-    fires on text the author wrote. That sent valid input to the regex fallback,
-    which corrupted it: this case returned 'text]]>' instead of the real text.
+    The declaration scan runs on raw text, so an abstract that legitimately
+    quotes "<!DOCTYPE" inside CDATA is refused and falls through to the regex
+    fallback, which mangles it. Blanking CDATA before the scan fixes that and
+    opens a hole, see test_regex_lexing_cannot_be_made_safe, so the false
+    positive is the safer half of the trade. A parser-level guard fixes both.
     """
     from nmdc_metadata_suggestor_ai_tool.doi_ingestion.doi_utils import strip_jats_xml
 
-    assert strip_jats_xml("<p><![CDATA[Example <!DOCTYPE x> text]]></p>") == (
-        "Example <!DOCTYPE x> text"
+    root, reason = parse_untrusted_xml("<root><![CDATA[<!DOCTYPE x>]]></root>")
+    assert root is None
+    assert reason == "XML contains unsafe declarations"
+    # The caller degrades to the regex fallback rather than failing.
+    assert strip_jats_xml("<p><![CDATA[Example <!DOCTYPE x> text]]></p>") == "text]]>"
+
+
+def test_regex_lexing_cannot_be_made_safe() -> None:
+    """Why the scan does not try to skip CDATA.
+
+    A comment can open inside a CDATA marker and close after a real DOCTYPE, so
+    any regex that treats comments and CDATA as independent regions can be made
+    to blank out a live declaration while ElementTree still parses and expands
+    it. Verified: blanking CDATA alone let this payload through and &e; expanded.
+    """
+    payload = (
+        '<!-- <![CDATA[ --><!DOCTYPE root [<!ENTITY e "expanded">]><root>&e;</root><!-- ]]> -->'
     )
-
-
-def test_xxe_inside_cdata_parses_without_reading_the_file(tmp_path: Path) -> None:
-    """Inert, because CDATA contents are never markup."""
-    secret = tmp_path / "secret.txt"
-    secret.write_text("SENSITIVE-FILE-CONTENTS")
-    payload = f'<root><![CDATA[<!DOCTYPE x [<!ENTITY xxe SYSTEM "file://{secret}">]>]]></root>'
-
     root, reason = parse_untrusted_xml(payload)
-    assert root is not None, reason
-    text = ET.tostring(root, encoding="unicode", method="text")
-    assert "SENSITIVE-FILE-CONTENTS" not in text
+    assert root is None, "a declaration hidden across lexical regions must still be refused"
+    assert reason == "XML contains unsafe declarations"
 
 
 @pytest.mark.parametrize(

--- a/tests/test_xml_safety.py
+++ b/tests/test_xml_safety.py
@@ -1,5 +1,9 @@
 """Tests for the shared untrusted-XML parsing guards."""
 
+from pathlib import Path
+
+import pytest
+
 from nmdc_metadata_suggestor_ai_tool.xml_safety import parse_untrusted_xml
 
 BILLION_LAUGHS = (
@@ -66,3 +70,88 @@ def test_reports_malformed_xml() -> None:
     root, reason = parse_untrusted_xml("<not-closed>")
     assert root is None
     assert reason == "response was not valid XML"
+
+
+# --- strip_jats_xml: abstracts come off the network, so the same guards apply ---
+
+
+def _billion_laughs(levels: int = 5) -> str:
+    """A bounded entity-expansion payload. Bounded so a regression cannot hang CI."""
+    entities = '<!ENTITY a0 "lol">' + "".join(
+        f'<!ENTITY a{i} "&a{i - 1};&a{i - 1};&a{i - 1};&a{i - 1};">' for i in range(1, levels + 1)
+    )
+    return f'<?xml version="1.0"?><!DOCTYPE x [{entities}]><root>&a{levels};</root>'
+
+
+def test_strip_jats_xml_still_strips_ordinary_markup() -> None:
+    from nmdc_metadata_suggestor_ai_tool.doi_ingestion.doi_utils import strip_jats_xml
+
+    assert strip_jats_xml("<p>Soil <italic>microbial</italic> communities</p>") == (
+        "Soil microbial communities"
+    )
+
+
+def test_strip_jats_xml_unescapes_entities() -> None:
+    from nmdc_metadata_suggestor_ai_tool.doi_ingestion.doi_utils import strip_jats_xml
+
+    assert strip_jats_xml("<p>a &amp; b</p>") == "a & b"
+
+
+def test_strip_jats_xml_does_not_expand_declared_entities() -> None:
+    from nmdc_metadata_suggestor_ai_tool.doi_ingestion.doi_utils import strip_jats_xml
+
+    out = strip_jats_xml(_billion_laughs())
+    assert "lollol" not in out
+    assert len(out) < 200
+
+
+def test_strip_jats_xml_does_not_read_local_files(tmp_path: Path) -> None:
+    """An external-entity payload must not reach the filesystem."""
+    from nmdc_metadata_suggestor_ai_tool.doi_ingestion.doi_utils import strip_jats_xml
+
+    secret = tmp_path / "secret.txt"
+    secret.write_text("SENSITIVE-FILE-CONTENTS")
+    payload = (
+        '<?xml version="1.0"?>'
+        f'<!DOCTYPE x [<!ENTITY xxe SYSTEM "file://{secret}">]>'
+        "<root>&xxe;</root>"
+    )
+    assert "SENSITIVE-FILE-CONTENTS" not in strip_jats_xml(payload)
+
+
+def test_strip_jats_xml_routes_through_the_shared_guard(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Pins the guard into the call path.
+
+    The wrapping element and the declaration guard each block entity expansion
+    on their own, so a test that only feeds in a hostile abstract keeps passing
+    when either one is removed. It takes losing both to fail. This asserts the
+    guard is actually reached, so dropping it back to a bare ElementTree parse
+    is caught on its own.
+    """
+    from nmdc_metadata_suggestor_ai_tool.doi_ingestion import doi_utils
+
+    seen: list[str] = []
+    real = doi_utils.parse_untrusted_xml
+
+    def _spy(xml_text: str | bytes, **kwargs: object) -> object:
+        seen.append(str(xml_text))
+        return real(xml_text, **kwargs)  # type: ignore[arg-type]
+
+    monkeypatch.setattr(doi_utils, "parse_untrusted_xml", _spy)
+    doi_utils.strip_jats_xml("<p>hello</p>")
+
+    assert seen, "strip_jats_xml must parse through parse_untrusted_xml"
+    assert seen[0] == "<root><p>hello</p></root>", "the wrapping element is a second layer; keep it"
+
+
+def test_declaration_guard_rejects_payloads_with_and_without_a_wrapper() -> None:
+    """The guard does not depend on how the caller wraps the payload."""
+    root, reason = parse_untrusted_xml(f"<root>{_billion_laughs()}</root>")
+    assert root is None
+    assert reason == "XML contains unsafe declarations"
+
+    root, reason = parse_untrusted_xml(_billion_laughs())
+    assert root is None
+    assert reason == "XML contains unsafe declarations"

--- a/tests/test_xml_safety.py
+++ b/tests/test_xml_safety.py
@@ -43,15 +43,21 @@ def test_rejects_entity_declarations() -> None:
     # Every caller relies on this: ElementTree expands internal entities, so a
     # billion-laughs payload must be refused before it reaches the parser.
     root, reason = parse_untrusted_xml(BILLION_LAUGHS)
-    assert root is None
-    assert reason == "XML contains unsafe declarations"
+    assert root is None, reason
 
 
-def test_rejects_doctype_regardless_of_spacing_and_case() -> None:
+def test_rejects_malformed_declarations_and_stray_entities() -> None:
+    """Renamed from test_rejects_doctype_regardless_of_spacing_and_case.
+
+    It no longer describes the behaviour: a well-formed DOCTYPE carrying no
+    entities is now allowed, because JATS uses one. These three payloads are
+    still refused, but as malformed XML rather than as unsafe declarations, so
+    the assertion is on the refusal rather than on the reason string.
+    """
     for payload in ("<! doctype doc><doc/>", "<!DocType doc><doc/>", "<!ENTITY x 'y'><doc/>"):
         root, reason = parse_untrusted_xml(payload)
-        assert root is None, payload
-        assert reason == "XML contains unsafe declarations"
+        assert root is None, f"{payload} was accepted"
+        assert reason is not None
 
 
 def test_rejects_oversized_payload_before_parsing() -> None:
@@ -149,33 +155,39 @@ def test_strip_jats_xml_routes_through_the_shared_guard(
 def test_declaration_guard_rejects_payloads_with_and_without_a_wrapper() -> None:
     """The guard does not depend on how the caller wraps the payload."""
     root, reason = parse_untrusted_xml(f"<root>{_billion_laughs()}</root>")
-    assert root is None
-    assert reason == "XML contains unsafe declarations"
+    assert root is None, reason
 
     root, reason = parse_untrusted_xml(_billion_laughs())
-    assert root is None
-    assert reason == "XML contains unsafe declarations"
+    assert root is None, reason
 
 
 # --- CDATA holds character data, so a declaration inside one is text ---
 
 
-def test_cdata_containing_a_doctype_is_rejected_a_known_false_positive() -> None:
-    """Documents a real false positive we are choosing to keep.
+def test_cdata_quoting_a_doctype_round_trips() -> None:
+    """An abstract may legitimately quote markup, and must survive intact.
 
-    The declaration scan runs on raw text, so an abstract that legitimately
-    quotes "<!DOCTYPE" inside CDATA is refused and falls through to the regex
-    fallback, which mangles it. Blanking CDATA before the scan fixes that and
-    opens a hole, see test_regex_lexing_cannot_be_made_safe, so the false
-    positive is the safer half of the trade. A parser-level guard fixes both.
+    The previous regex guard refused this and degraded to a tag-stripping
+    fallback that returned "text]]>". Guarding at the parser removes the
+    false positive without weakening anything.
     """
     from nmdc_metadata_suggestor_ai_tool.doi_ingestion.doi_utils import strip_jats_xml
 
-    root, reason = parse_untrusted_xml("<root><![CDATA[<!DOCTYPE x>]]></root>")
-    assert root is None
-    assert reason == "XML contains unsafe declarations"
-    # The caller degrades to the regex fallback rather than failing.
-    assert strip_jats_xml("<p><![CDATA[Example <!DOCTYPE x> text]]></p>") == "text]]>"
+    assert strip_jats_xml("<p><![CDATA[Example <!DOCTYPE x> text]]></p>") == (
+        "Example <!DOCTYPE x> text"
+    )
+
+
+def test_document_type_declaration_alone_is_allowed() -> None:
+    """A DOCTYPE without entities is normal in JATS and must not be refused.
+
+    Three of four Europe PMC full texts sampled on 2026-08-24 carried
+    ``<!DOCTYPE article``. The regex guard refused all three, so supplement
+    caption extraction silently returned nothing for them.
+    """
+    root, reason = parse_untrusted_xml("<!DOCTYPE article><root>hi</root>")
+    assert root is not None, reason
+    assert root.text == "hi"
 
 
 def test_regex_lexing_cannot_be_made_safe() -> None:
@@ -216,8 +228,7 @@ def test_regex_lexing_cannot_be_made_safe() -> None:
 def test_blanking_cdata_cannot_hide_a_real_declaration(payload: str) -> None:
     """A real DOCTYPE precedes the root element, so it can never sit inside CDATA."""
     root, reason = parse_untrusted_xml(payload)
-    assert root is None
-    assert reason == "XML contains unsafe declarations"
+    assert root is None, reason
 
 
 # --- the size limit must stay wired into the caller, not just exist in the helper ---
@@ -250,3 +261,32 @@ def test_supplement_caption_parsing_enforces_the_size_limit(
 
     monkeypatch.setattr(shared, "MAX_EUROPEPMC_FULLTEXT_XML_CHARS", 10)
     assert not shared.parse_supplement_captions(jats)
+
+
+def test_real_jats_doctype_is_accepted() -> None:
+    """Regression for a live bug: JATS carries a DOCTYPE and we refused it.
+
+    Sampled four Europe PMC full texts on 2026-08-24. Three began with
+    ``<!DOCTYPE article ...``, and the regex guard refused all three, so
+    ``parse_supplement_captions`` returned nothing for them. PMC9950430 alone
+    holds 23 supplement elements and now yields 12 captions.
+
+    The declaration below is the real one from PMC9950430, trimmed to its
+    public and system identifiers.
+    """
+    doctype = (
+        '<!DOCTYPE article PUBLIC "-//NLM//DTD JATS (Z39.96) '
+        'Journal Archiving and Interchange DTD v1.2 20190208//EN" '
+        '"JATS-archivearticle1.dtd">'
+    )
+    root, reason = parse_untrusted_xml(f"{doctype}<article><body><p>hi</p></body></article>")
+    assert root is not None, f"real JATS must parse, got {reason!r}"
+    assert root.findtext("./body/p") == "hi"
+
+
+def test_external_dtd_reference_is_not_fetched() -> None:
+    """The JATS DOCTYPE names a system DTD; it must never be retrieved."""
+    doctype = '<!DOCTYPE article SYSTEM "http://127.0.0.1:9/nonexistent.dtd">'
+    root, reason = parse_untrusted_xml(f"{doctype}<article>hi</article>")
+    assert root is not None, reason
+    assert root.text == "hi"

--- a/tests/test_xml_safety.py
+++ b/tests/test_xml_safety.py
@@ -1,5 +1,6 @@
 """Tests for the shared untrusted-XML parsing guards."""
 
+import xml.etree.ElementTree as ET
 from pathlib import Path
 
 import pytest
@@ -153,5 +154,60 @@ def test_declaration_guard_rejects_payloads_with_and_without_a_wrapper() -> None
     assert reason == "XML contains unsafe declarations"
 
     root, reason = parse_untrusted_xml(_billion_laughs())
+    assert root is None
+    assert reason == "XML contains unsafe declarations"
+
+
+# --- CDATA holds character data, so a declaration inside one is text ---
+
+
+def test_cdata_containing_a_doctype_is_not_rejected() -> None:
+    """An abstract may legitimately quote markup.
+
+    The declaration scan runs before parsing, so without blanking CDATA first it
+    fires on text the author wrote. That sent valid input to the regex fallback,
+    which corrupted it: this case returned 'text]]>' instead of the real text.
+    """
+    from nmdc_metadata_suggestor_ai_tool.doi_ingestion.doi_utils import strip_jats_xml
+
+    assert strip_jats_xml("<p><![CDATA[Example <!DOCTYPE x> text]]></p>") == (
+        "Example <!DOCTYPE x> text"
+    )
+
+
+def test_xxe_inside_cdata_parses_without_reading_the_file(tmp_path: Path) -> None:
+    """Inert, because CDATA contents are never markup."""
+    secret = tmp_path / "secret.txt"
+    secret.write_text("SENSITIVE-FILE-CONTENTS")
+    payload = f'<root><![CDATA[<!DOCTYPE x [<!ENTITY xxe SYSTEM "file://{secret}">]>]]></root>'
+
+    root, reason = parse_untrusted_xml(payload)
+    assert root is not None, reason
+    text = ET.tostring(root, encoding="unicode", method="text")
+    assert "SENSITIVE-FILE-CONTENTS" not in text
+
+
+@pytest.mark.parametrize(
+    "payload",
+    [
+        pytest.param(
+            '<![CDATA[]]><!DOCTYPE x [<!ENTITY e "P">]><root>&e;</root>', id="cdata-then-doctype"
+        ),
+        pytest.param(
+            '<![CDATA[ <!DOCTYPE x [<!ENTITY e "P">]><root>&e;</root>', id="unterminated-cdata"
+        ),
+        pytest.param(
+            '<!DOCTYPE x [<!ENTITY e "<![CDATA[">]><root>&e;</root>', id="doctype-wrapping-cdata"
+        ),
+        pytest.param(
+            '<![CDATA[a]]><!DOCTYPE x [<!ENTITY e "P">]><![CDATA[b]]><root>&e;</root>',
+            id="declaration-between-cdata-sections",
+        ),
+        pytest.param('<![CDATA[]]><!doctype x [<!entity e "P">]><root>&e;</root>', id="lowercase"),
+    ],
+)
+def test_blanking_cdata_cannot_hide_a_real_declaration(payload: str) -> None:
+    """A real DOCTYPE precedes the root element, so it can never sit inside CDATA."""
+    root, reason = parse_untrusted_xml(payload)
     assert root is None
     assert reason == "XML contains unsafe declarations"

--- a/uv.lock
+++ b/uv.lock
@@ -1,5 +1,5 @@
 version = 1
-revision = 2
+revision = 3
 requires-python = ">=3.12"
 resolution-markers = [
     "python_full_version >= '3.15'",
@@ -496,6 +496,15 @@ wheels = [
 ]
 
 [[package]]
+name = "defusedxml"
+version = "0.7.1"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/0f/d5/c66da9b79e5bdb124974bfe172b4daf3c984ebd9c2a06e2b8a4dc7331c72/defusedxml-0.7.1.tar.gz", hash = "sha256:1bb3032db185915b62d7c6209c5a8792be6a32ab2fedacc84e01b52c51aa3e69", size = 75520, upload-time = "2021-03-08T10:59:26.269Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/07/6c/aa3f2f849e01cb6a001cd8554a88d4c77c5c1a31c95bdf1cf9301e6d9ef4/defusedxml-0.7.1-py2.py3-none-any.whl", hash = "sha256:a352e7e428770286cc899e2542b6cdaedb2b4953ff269a210103ec58f6198a61", size = 25604, upload-time = "2021-03-08T10:59:24.45Z" },
+]
+
+[[package]]
 name = "deprecated"
 version = "1.3.1"
 source = { registry = "https://pypi.org/simple" }
@@ -984,6 +993,7 @@ source = { editable = "." }
 dependencies = [
     { name = "claude-agent-sdk" },
     { name = "curl-cffi" },
+    { name = "defusedxml" },
     { name = "google-auth" },
     { name = "google-genai" },
     { name = "langfuse" },
@@ -1009,6 +1019,7 @@ dev = [
     { name = "pytest-timeout" },
     { name = "responses" },
     { name = "ruff" },
+    { name = "types-defusedxml" },
     { name = "types-requests" },
 ]
 
@@ -1016,6 +1027,7 @@ dev = [
 requires-dist = [
     { name = "claude-agent-sdk", specifier = ">=0.2.87" },
     { name = "curl-cffi", specifier = ">=0.13.0" },
+    { name = "defusedxml", specifier = ">=0.7.1" },
     { name = "google-auth", specifier = ">=2.0.0" },
     { name = "google-genai", specifier = ">=1.62.0" },
     { name = "langfuse", specifier = "==4.14.0" },
@@ -1041,6 +1053,7 @@ dev = [
     { name = "pytest-timeout", specifier = ">=2.3.0" },
     { name = "responses", specifier = ">=0.25.0" },
     { name = "ruff", specifier = ">=0.3.0" },
+    { name = "types-defusedxml", specifier = ">=0.7.0.20260504" },
     { name = "types-requests", specifier = ">=2.31.0" },
 ]
 
@@ -1861,6 +1874,15 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/ae/5f/57ff8b434839e70dab45601284ea413e947a63799891b7553e5960a793a8/tqdm-4.68.4.tar.gz", hash = "sha256:19829c9673638f2a0b8617da4cdcb927e831cd88bcfcb6e78d42a4d1af131520", size = 792418, upload-time = "2026-07-07T09:58:18.369Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/22/2a/5e5e750890ada51017d18d0d4c30da696e5b5bd3180947729927628fc3cb/tqdm-4.68.4-py3-none-any.whl", hash = "sha256:5168118b2368f48c561afda8020fd79195b1bdb0bdf8086b88442c267a315dc2", size = 676612, upload-time = "2026-07-07T09:58:16.256Z" },
+]
+
+[[package]]
+name = "types-defusedxml"
+version = "0.7.0.20260504"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/da/d2/4553c8fa9cdebfe1e84b950cf790a4d2376a97fa016e43f7c65323fa6c7d/types_defusedxml-0.7.0.20260504.tar.gz", hash = "sha256:2ab2828a3f97111ba1c16cee273ad4124a831fc9198c41bf8368ff6ea48ad300", size = 10729, upload-time = "2026-05-04T05:22:50.192Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/bf/2d/8a4b5ba1d732b8bc691f0efbb1c6f77cb5f6f473b2afe181d83d910773c5/types_defusedxml-0.7.0.20260504-py3-none-any.whl", hash = "sha256:a959e3a0a43b93e464bd625d91ec9193a2703ddc10443bdd627792485fae0b10", size = 13467, upload-time = "2026-05-04T05:22:49.319Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
## Why

Closes https://github.com/microbiomedata/nmdc-metadata-suggestor-ai-tool/issues/100, taking the
`defusedxml` fix that issue originally proposed.

This PR started as "route the last raw `ET.fromstring` through the existing guard", and review
turned it into something more useful: **the existing guard was refusing most real Europe PMC full
text.** It also had a bypass. Both are fixed by guarding at the parser instead of with a regex.

## The live bug

The guard refused any payload containing `<!DOCTYPE`. But a plain document type declaration carries
no entities and is normal in JATS. Of four Europe PMC full texts sampled on 2026-08-24, three began
with `<!DOCTYPE article`:

| document | supplement elements | captions before | captions after |
|---|---|---|---|
| PMC9950430 | 23 | 0 | **12** |
| PMC8536711 | 2 | 0 | **1** |
| PMC6013943 | 0 | 0 | 0 |
| PMC7796900 | 8 | 0 | 0 |

`parse_supplement_captions` returned `{}` for all three and said nothing about why. That is
https://github.com/microbiomedata/nmdc-metadata-suggestor-ai-tool/pull/132's feature, silently not
working for most inputs.

PMC7796900 has no DOCTYPE, parsed fine before and after, and still yields no captions despite eight
supplement elements. That is a separate pre-existing problem, not touched here.

## The bypass

Mid-review I fixed a false positive by blanking CDATA before the scan. Copilot caught that this
opened a hole, and it was right:

```
<!-- <![CDATA[ --><!DOCTYPE root [<!ENTITY e "expanded">]><root>&e;</root><!-- ]]> -->
```

Well-formed XML. A comment opens inside a CDATA marker and closes after a real declaration, so the
scan saw `<!--  -->` and passed it while ElementTree expanded the entity. Reverted in 7c0f9b9.

The lesson is not about that regex. Comments, CDATA and processing instructions are lexical regions
a regex cannot track across, so any skip-this-region rule can be straddled.

## What changed

`parse_untrusted_xml` now parses with `defusedxml`, which refuses entity declarations and external
references inside the parser. Measured against the same payloads:

| payload | result |
|---|---|
| entity expansion (billion laughs) | refused |
| external entity reading a local file | refused |
| the comment/CDATA bypass above | refused |
| real JATS `<!DOCTYPE article ...>` | **accepted** |
| abstract quoting `<!DOCTYPE` inside CDATA | **accepted, text intact** |

Adds `defusedxml` and dev-only `types-defusedxml`, matching how `types-requests` is already
declared.

Also still in this PR from before review: `strip_jats_xml` routed through the shared guard, a size
limit on the Europe PMC parse with a test that fails if it is removed, and that limit documented in
`README.md` and `.env.example`.

## Validation

274 tests pass, up from 257. `ruff check`, `ruff format --check` on 87 files, `mypy src` on 51
files, and `deptry` all clean.

Two pre-existing tests asserted the old guard's exact reason strings. Those payloads are still
refused, but as malformed XML rather than as unsafe declarations, so they now assert the refusal.
One is renamed, because "rejects doctype regardless of spacing and case" is no longer what happens.

Verified by mutation: restoring the regex scan fails four tests, and removing `max_chars` from the
caller fails one.

## Scope and complexity

Small in diff, larger in consequence: it changes what the tool accepts. The direction is more
permissive on document type declarations and stricter on everything that actually carries risk.

`defusedxml` is a new runtime dependency, which is a call for @hesspnnl rather than mine. The
reasoning, including the argument I made against it earlier and why it was wrong, is on issue 100.
