### PR TITLE
Remove the dead run target and repoint the DOI targets

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -9,7 +9,7 @@
 # Background: docs/makefile-phony.md.
 FILE_TARGETS =
 
-.PHONY: help all-install prod-install dev-install test test-integration lint check-phony format security check-deps clean run validate-doi classify-doi classify-fixture get-abstract get-abstracts
+.PHONY: help all-install prod-install dev-install test test-integration lint check-phony format security check-deps clean validate-doi classify-doi classify-fixture get-abstract get-abstracts
 
 help: ## Show this help message
 	@echo "Usage: make [target]"
@@ -65,10 +65,7 @@ clean: ## Clean up generated files
 	find . -type d -name __pycache__ -exec rm -rf {} +
 	find . -type f -name "*.pyc" -delete
 
-run: ## Run the application locally
-	uv run nmdc-suggestor
-
-DOI_CLI = uv run python -m nmdc_metadata_suggestor.cli.doi_cli
+DOI_CLI = uv run python -m nmdc_metadata_suggestor_ai_tool.cli.doi_cli
 
 validate-doi: ## Validate a DOI (usage: make validate-doi DOI=10.1038/s41564-020-00861-0)
 	$(DOI_CLI) validate $(DOI)


### PR DESCRIPTION
## Why

Closes https://github.com/microbiomedata/nmdc-metadata-suggestor-ai-tool/issues/156 and
https://github.com/microbiomedata/nmdc-metadata-suggestor-ai-tool/issues/154. Two Makefile targets
pointed at things that do not exist.

`run` called `uv run nmdc-suggestor`, but `pyproject.toml` has no `[project.scripts]` section, so
that entry point was never installed. @hesspnnl called it on 156: "lets remove - too many entry
points to need to worry about."

`DOI_CLI` still named `nmdc_metadata_suggestor.cli.doi_cli`. The package was renamed to
`nmdc_metadata_suggestor_ai_tool` in March and this line never followed, so **all five DOI targets
failed**: `validate-doi`, `classify-doi`, `classify-fixture`, `get-abstract`, `get-abstracts`.

## Validation

Reproduced both before fixing, and confirmed after.

Before: `make classify-fixture` raised
`ModuleNotFoundError: No module named 'nmdc_metadata_suggestor'`, and `make run` failed with
`Failed to spawn: nmdc-suggestor`.

After: `make classify-fixture` returns classifications, and
`make classify-doi DOI=10.1038/s41564-020-00861-0` resolves through Crossref, reporting
`registration_agency: Crossref` and `inferred_nmdc_category: publication_doi`.

`.PHONY` regenerated from the remaining 17 targets, so `make check-phony` still passes. `make lint`
and 263 tests green.

## Scope

Three lines of `Makefile`. No source or test file touched.

Note for sequencing: https://github.com/microbiomedata/nmdc-metadata-suggestor-ai-tool/pull/66 also
edits this `Makefile`, adding `ruff format --check` to the `lint` target and one entry to `.PHONY`.
Different regions, but whichever merges second may want a trivial rebase.
