### PR TITLE
129 add award doi api

### DIFF
--- a/src/nmdc_metadata_suggestor_ai_tool/constants.py
+++ b/src/nmdc_metadata_suggestor_ai_tool/constants.py
@@ -115,7 +115,6 @@ TARGET_PROVIDER_PREFIXES: dict[str, str] = {
     "10.17504": "cyverse",
     "10.5281": "zenodo",
     "10.11578": "osti",
-    "10.46936": "osti_award",
 }
 
 TARGET_PROVIDER_KEYWORDS: dict[str, str] = {

--- a/src/nmdc_metadata_suggestor_ai_tool/constants.py
+++ b/src/nmdc_metadata_suggestor_ai_tool/constants.py
@@ -49,6 +49,7 @@ OPENALEX_API_URL = "https://api.openalex.org/works"
 # OSTI
 OSTI_API_URL = "https://www.osti.gov/api/v1/records"
 OSTI_E2_API_URL = "https://www.osti.gov/elink2api/records"
+OSTI_AWARD_API_URL = "https://www.osti.gov/award-doi-service/api/v1/search"
 
 # Europe PMC
 EUROPEPMC_REST_URL = "https://www.ebi.ac.uk/europepmc/webservices/rest"
@@ -114,6 +115,7 @@ TARGET_PROVIDER_PREFIXES: dict[str, str] = {
     "10.17504": "cyverse",
     "10.5281": "zenodo",
     "10.11578": "osti",
+    "10.46936": "osti_award",
 }
 
 TARGET_PROVIDER_KEYWORDS: dict[str, str] = {

--- a/src/nmdc_metadata_suggestor_ai_tool/doi_ingestion/main.py
+++ b/src/nmdc_metadata_suggestor_ai_tool/doi_ingestion/main.py
@@ -27,8 +27,7 @@ from nmdc_metadata_suggestor_ai_tool.doi_ingestion.jgi import try_jgi
 from nmdc_metadata_suggestor_ai_tool.doi_ingestion.kbase import try_kbase
 from nmdc_metadata_suggestor_ai_tool.doi_ingestion.massive import try_massive
 from nmdc_metadata_suggestor_ai_tool.doi_ingestion.openalex import try_openalex
-from nmdc_metadata_suggestor_ai_tool.doi_ingestion.osti import try_osti
-from nmdc_metadata_suggestor_ai_tool.doi_ingestion.osti import try_osti_award
+from nmdc_metadata_suggestor_ai_tool.doi_ingestion.osti import try_osti, try_osti_award
 from nmdc_metadata_suggestor_ai_tool.doi_ingestion.pubmed import try_pubmed
 from nmdc_metadata_suggestor_ai_tool.doi_ingestion.zenodo import try_zenodo
 from nmdc_metadata_suggestor_ai_tool.models.doi import DoiClassification, SourceRetrievalResult
@@ -449,11 +448,14 @@ def _fetch_osti(
     """Fetch and wrap context from OSTI API."""
     return _fetch_resolver_context(doi, provider, "osti", attempts, source_errors, try_osti)
 
+
 def _fetch_osti_award(
     doi: str, provider: str | None, attempts: list[str], source_errors: SourceErrors
 ) -> SourceRetrievalResult | None:
     """Fetch and wrap context from OSTI Award API."""
-    return _fetch_resolver_context(doi, provider, "osti_award", attempts, source_errors, try_osti_award)
+    return _fetch_resolver_context(
+        doi, provider, "osti_award", attempts, source_errors, try_osti_award
+    )
 
 
 _SOURCE_FETCHERS: dict[str, Fetcher] = {

--- a/src/nmdc_metadata_suggestor_ai_tool/doi_ingestion/main.py
+++ b/src/nmdc_metadata_suggestor_ai_tool/doi_ingestion/main.py
@@ -486,5 +486,4 @@ _PROVIDER_API_SOURCES = {
     "cyverse",
     "zenodo",
     "osti",
-    "osti_award",
 }

--- a/src/nmdc_metadata_suggestor_ai_tool/doi_ingestion/main.py
+++ b/src/nmdc_metadata_suggestor_ai_tool/doi_ingestion/main.py
@@ -28,6 +28,7 @@ from nmdc_metadata_suggestor_ai_tool.doi_ingestion.kbase import try_kbase
 from nmdc_metadata_suggestor_ai_tool.doi_ingestion.massive import try_massive
 from nmdc_metadata_suggestor_ai_tool.doi_ingestion.openalex import try_openalex
 from nmdc_metadata_suggestor_ai_tool.doi_ingestion.osti import try_osti
+from nmdc_metadata_suggestor_ai_tool.doi_ingestion.osti import try_osti_award
 from nmdc_metadata_suggestor_ai_tool.doi_ingestion.pubmed import try_pubmed
 from nmdc_metadata_suggestor_ai_tool.doi_ingestion.zenodo import try_zenodo
 from nmdc_metadata_suggestor_ai_tool.models.doi import DoiClassification, SourceRetrievalResult
@@ -448,6 +449,12 @@ def _fetch_osti(
     """Fetch and wrap context from OSTI API."""
     return _fetch_resolver_context(doi, provider, "osti", attempts, source_errors, try_osti)
 
+def _fetch_osti_award(
+    doi: str, provider: str | None, attempts: list[str], source_errors: SourceErrors
+) -> SourceRetrievalResult | None:
+    """Fetch and wrap context from OSTI Award API."""
+    return _fetch_resolver_context(doi, provider, "osti_award", attempts, source_errors, try_osti_award)
+
 
 _SOURCE_FETCHERS: dict[str, Fetcher] = {
     "edi": _fetch_edi,
@@ -465,6 +472,7 @@ _SOURCE_FETCHERS: dict[str, Fetcher] = {
     "openalex": _fetch_openalex,
     "pubmed": _fetch_pubmed,
     "osti": _fetch_osti,
+    "osti_award": _fetch_osti_award,
 }
 
 _PROVIDER_API_SOURCES = {
@@ -478,4 +486,5 @@ _PROVIDER_API_SOURCES = {
     "cyverse",
     "zenodo",
     "osti",
+    "osti_award",
 }

--- a/src/nmdc_metadata_suggestor_ai_tool/doi_ingestion/osti.py
+++ b/src/nmdc_metadata_suggestor_ai_tool/doi_ingestion/osti.py
@@ -1,8 +1,10 @@
 """
-A module to attempt to retrieve publication abstract and PDF bytes via a provided OSTI DOI.
+A module to attempt to retrieve publication's abstract and PDF bytes or an award's description
+ via a provided OSTI DOI or OSTI award DOI.
 
 This module provides direct API-based retrieval of OSTI DOIs abstracts
 and full-text PDFs links starting from OSTI, then calling Crossref and/or Europe PMC.
+It also provides direct API-based retrieval of OSTI award DOIs descriptions.
 """
 
 import requests
@@ -11,6 +13,7 @@ from nmdc_metadata_suggestor_ai_tool.constants import (
     DEFAULT_TIMEOUT,
     OSTI_API_URL,
     OSTI_E2_API_URL,
+    OSTI_AWARD_API_URL,
     USER_AGENT,
 )
 from nmdc_metadata_suggestor_ai_tool.doi_ingestion.doi_utils import (
@@ -112,3 +115,59 @@ def query_osti_by_doi(osti_doi: str) -> list[dict]:
         )
         response.raise_for_status()
         return response.json()  # type: ignore
+
+
+def query_osti_by_award_doi(award_doi: str) -> list[dict]:
+    """
+    Query OSTI award API for a given award DOI and return the JSON response.
+    """
+    params = {
+        "award_doi": award_doi,
+    }
+    headers = {"User-Agent": USER_AGENT}
+    osti_url = f"{OSTI_AWARD_API_URL}"
+    response = request_with_retry(
+        "GET",
+        osti_url,
+        timeout=DEFAULT_TIMEOUT,
+        headers=headers,
+        params=params,
+    )
+    response.raise_for_status()
+    return response.json()  # type: ignore
+
+
+def try_osti_award(award_doi: str, errors: list[str] | None = None) -> ResolverContext | None:
+    """Return abstract/description context from OSTI award API if available."""
+    try:
+        data = query_osti_by_award_doi(award_doi=award_doi)
+    except requests.RequestException as exc:
+        append_error(errors, f"OSTI Award API request failed: {exc.__class__.__name__}")
+        return None
+    except ValueError:
+        append_error(errors, "OSTI Award API returned invalid JSON")
+        return None
+
+    if not data or len(data) == 0:
+        append_error(errors, f"No award found for award DOI: {award_doi}")
+        return None
+
+    description = None
+
+    # When querying an award DOI there should only be one record
+    raw_description = data[0].get("description")
+    if isinstance(raw_description, str):
+        description = clean_text(raw_description)
+    else:
+        append_error(errors, "No description found in OSTI Award record")
+
+    if not description:
+        append_error(errors, "OSTI Award record contained no description")
+        return None
+
+    return ResolverContext(
+        text=description,
+        raw_text=raw_description if isinstance(raw_description, str) else None,
+        kind="description",
+        source="osti_award",
+    )

--- a/src/nmdc_metadata_suggestor_ai_tool/doi_ingestion/osti.py
+++ b/src/nmdc_metadata_suggestor_ai_tool/doi_ingestion/osti.py
@@ -12,8 +12,8 @@ import requests
 from nmdc_metadata_suggestor_ai_tool.constants import (
     DEFAULT_TIMEOUT,
     OSTI_API_URL,
-    OSTI_E2_API_URL,
     OSTI_AWARD_API_URL,
+    OSTI_E2_API_URL,
     USER_AGENT,
 )
 from nmdc_metadata_suggestor_ai_tool.doi_ingestion.doi_utils import (


### PR DESCRIPTION
Resolves #129 

This PR adds functionality to the `osti.py` file by implementing OSTI award API querying.
This implementation mimics the existing API querying code.

To make this functionality usable, supporting changes in `main.py` and `constants.py` were added
- Adding a fetcher 
- Adding `osti_award` to `_SOURCE_FETCHERS`
- Adding the OSTI award API url as a constant


This PR is in progress, things left to do:
- Ensure the added changes are enough for functionality
- Once that's done, update test files